### PR TITLE
some better logging logic

### DIFF
--- a/src/common/delivery/build/local/npm/npmLogInterpreter.ts
+++ b/src/common/delivery/build/local/npm/npmLogInterpreter.ts
@@ -40,7 +40,7 @@ export const NpmLogInterpreter: InterpretLog = log => {
 
     return {
         message: recognizedInterpretation.message || defaultMessage,
-        relevantPart: relevantLines.join("\n"),
+        relevantPart: "```" + relevantLines.join("\n") + "```",
     };
 };
 

--- a/src/common/delivery/build/local/npm/npmLogInterpreter.ts
+++ b/src/common/delivery/build/local/npm/npmLogInterpreter.ts
@@ -40,7 +40,7 @@ export const NpmLogInterpreter: InterpretLog = log => {
 
     return {
         message: recognizedInterpretation.message || defaultMessage,
-        relevantPart: "```" + relevantLines.join("\n") + "```",
+        relevantPart: "```\n" + relevantLines.join("\n") + "\n```",
     };
 };
 
@@ -57,7 +57,7 @@ function recognizeNpmRunError(lines: string[]): RecognizedLog {
     if (lastBreakBeforeCommand < 0) {
         return undefined;
     }
-    return { relevantLines: lines.slice(- lastBreakBeforeCommand)};
+    return { relevantLines: lines.slice(- Math.min(lastBreakBeforeCommand, 20))};
 }
 
 function recognizeMochaTest(lines: string[]): RecognizedLog {

--- a/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
+++ b/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
@@ -81,17 +81,9 @@ export async function displayBuildLogFailure(id: RemoteRepoRef,
         logger.debug("Do we have a log interpretation? " + !!logInterpretation);
         const interpretation = logInterpretation && logInterpretation.logInterpreter(buildLog);
         logger.debug("What did it say? " + stringify(interpretation));
-        // The deployer might have information about the failure; report it in the channels
-        if (interpretation) {
-            await reportFailureInterpretationToLinkedChannels("build", interpretation,
+            await reportFailureInterpretationToLinkedChannels("external-build", interpretation,
                 { log: buildLog, url: buildUrl }, id, addressChannels);
-        } else {
-            await addressChannels({
-                content: buildLog,
-                fileType: "text",
-                fileName: `build-${build.status}-${id.sha}.log`,
-            } as any);
-        }
+
     } else {
         return addressChannels("No build log detected for " + linkToSha(id));
     }


### PR DESCRIPTION
parse logs on pre-goal-hook failure
label failures from external builds differently (this could be the cause of too many snippets, we'll be able to tell)
if no interpretation, do the same default thing of sending the log only if there's no URL
and more logging about these logs.

If this doesn't fix the excessive snippetiness it should tell me more 

