### PR TITLE
Can now provide tag when running NPM publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/sdm/compare/0.1.0...HEAD
 
+### Added
+
+-   Can provide tag when publishing NPM package [#404][404]
+
+[404]: https://github.com/atomist/sdm/issues/404
+
 ## [0.1.0][] - 2018-05-16
 
 Initial release


### PR DESCRIPTION
Add tag as option when publishing a Node.js package using NPM.  Make
optional NPM publish options optional and only add them if they are
provided.  Use a package-local .npmrc rather than overwriting and then
deleting the user's .npmrc.

Remove errorFinder that reimplements the default.

Closes #404