### PR TITLE
publish should default to tagging by branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@jessitron/git-branch-to-npm-tag": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jessitron/git-branch-to-npm-tag/-/git-branch-to-npm-tag-1.0.1.tgz",
+      "integrity": "sha512-Oreo53gPxEa+s4r3BQ1QBV9CEuVxWtyPsULyk4KWD+t0l893KvvgPy9Qg2OHre2XjnJX/CelLITMwyqZn/mi3w=="
+    },
     "@octokit/rest": {
       "version": "14.0.9",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-14.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@atomist/automation-client": "0.17.2-20180605032022",
     "@atomist/slack-messages": "^0.12.1",
+    "@jessitron/git-branch-to-npm-tag": "^1.0.1",
     "archiver": "^2.1.1",
     "axios": "^0.18.0",
     "base64-js": "^1.2.3",

--- a/src/internal/delivery/build/local/npm/executePublish.ts
+++ b/src/internal/delivery/build/local/npm/executePublish.ts
@@ -15,6 +15,7 @@
  */
 
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { gitBranchToNpmTag } from "@jessitron/git-branch-to-npm-tag/lib";
 import * as fs from "fs-extra";
 import * as p from "path";
 import { ExecuteGoalResult } from "../../../../../api/goal/ExecuteGoalResult";
@@ -24,7 +25,6 @@ import { createStatus } from "../../../../../util/github/ghub";
 import { spawnAndWatch } from "../../../../../util/misc/spawned";
 import { ProjectIdentifier } from "../projectIdentifier";
 import { NpmPreparations } from "./npmBuilder";
-import { gitBranchToNpmTag } from "@jessitron/git-branch-to-npm-tag/lib";
 
 /**
  * Execute npm publish
@@ -67,7 +67,7 @@ export function executePublish(
             if (options.tag) {
                 args.push("--tag", options.tag);
             } else {
-                args.push("--tag", gitBranchToNpmTag(id.branch))
+                args.push("--tag", gitBranchToNpmTag(id.branch));
             }
 
             const result: ExecuteGoalResult = await spawnAndWatch(

--- a/src/internal/delivery/build/local/npm/executePublish.ts
+++ b/src/internal/delivery/build/local/npm/executePublish.ts
@@ -24,9 +24,13 @@ import { createStatus } from "../../../../../util/github/ghub";
 import { spawnAndWatch } from "../../../../../util/misc/spawned";
 import { ProjectIdentifier } from "../projectIdentifier";
 import { NpmPreparations } from "./npmBuilder";
+import { gitBranchToNpmTag } from "@jessitron/git-branch-to-npm-tag/lib";
 
 /**
  * Execute npm publish
+ *
+ * Tags with branch:name unless the `tag` option is specified
+ *
  * @param {ProjectLoader} projectLoader
  * @param {ProjectIdentifier} projectIdentifier
  * @param {PrepareForGoalExecution[]} preparations
@@ -62,6 +66,8 @@ export function executePublish(
             }
             if (options.tag) {
                 args.push("--tag", options.tag);
+            } else {
+                args.push("--tag", gitBranchToNpmTag(id.branch))
             }
 
             const result: ExecuteGoalResult = await spawnAndWatch(


### PR DESCRIPTION
This way we won't update the `latest` tag unless we specifically request it in the NpmOptions.