### PR TITLE
Restore newlines on writing each line

### DIFF
--- a/src/api-helper/log/DelimitedWriteProgressLogDecorator.ts
+++ b/src/api-helper/log/DelimitedWriteProgressLogDecorator.ts
@@ -50,7 +50,7 @@ export class DelimitedWriteProgressLogDecorator implements ProgressLog {
         if (splitLines.length > 1) {
             const completedLines = splitLines.slice(0, splitLines.length - 1);
             this.lineBuffer = splitLines[splitLines.length - 1];
-            completedLines.forEach(l => this.delegate.write(l));
+            completedLines.forEach(l => this.delegate.write(l + this.lineDelimiter));
         }
     }
 

--- a/src/api-helper/log/LoggingProgressLog.ts
+++ b/src/api-helper/log/LoggingProgressLog.ts
@@ -29,13 +29,13 @@ export class LoggingProgressLog implements ProgressLog {
 
     public write(pWhat: string) {
         let what = pWhat || "";
+        this.log += what;
         if (what.endsWith("\n\r") || what.endsWith("\r\n")) {
             what = what.slice(0, -2);
         }
         if (what.endsWith("\n")) {
             what = what.slice(0, -1);
         }
-        this.log += what;
         switch (this.level) {
             case "info" :
                 logger.info(what);

--- a/test/api-helper/log/DelimitedWriteProgressLogDecoratorTest.ts
+++ b/test/api-helper/log/DelimitedWriteProgressLogDecoratorTest.ts
@@ -17,6 +17,8 @@
 import * as assert from "power-assert";
 import {DelimitedWriteProgressLogDecorator} from "../../../src/api-helper/log/DelimitedWriteProgressLogDecorator";
 import { ProgressLog } from "../../../src/spi/log/ProgressLog";
+import { createEphemeralProgressLog } from "../../../src/api-helper/log/EphemeralProgressLog";
+import { HandlerContext } from "@atomist/automation-client";
 
 class ListProgressLog implements ProgressLog {
 
@@ -84,5 +86,18 @@ describe("DelimitedWriteProgressLogDecorator", () => {
             "I sleep all night and I work all day",
         ]);
     });
+
+    it("Should include newlines in its log property", async () => {
+        const delegateLog = await createEphemeralProgressLog({} as any, { name: "hi"} as any);
+        const log = new DelimitedWriteProgressLogDecorator(delegateLog, "\n");
+
+        log.write("I'm a lumberjack and I'm OK\nI sleep all");
+        log.write(" night and I work all day");
+        await log.flush();
+
+        assert.deepEqual(log.log,
+            "I'm a lumberjack and I'm OK\nI sleep all night and I work all day",
+        );
+    })
 
 });

--- a/test/api-helper/log/DelimitedWriteProgressLogDecoratorTest.ts
+++ b/test/api-helper/log/DelimitedWriteProgressLogDecoratorTest.ts
@@ -55,8 +55,8 @@ describe("DelimitedWriteProgressLogDecorator", () => {
         log.write("I sleep all night and I work all day\n");
 
         assert.deepEqual(delegateLog.logList, [
-            "I'm a lumberjack and I'm OK",
-            "I sleep all night and I work all day",
+            "I'm a lumberjack and I'm OK\n",
+            "I sleep all night and I work all day\n",
         ]);
     });
 
@@ -68,8 +68,8 @@ describe("DelimitedWriteProgressLogDecorator", () => {
         log.write(" night and I work all day\n");
 
         assert.deepEqual(delegateLog.logList, [
-            "I'm a lumberjack and I'm OK",
-            "I sleep all night and I work all day",
+            "I'm a lumberjack and I'm OK\n",
+            "I sleep all night and I work all day\n",
         ]);
     });
 
@@ -82,7 +82,7 @@ describe("DelimitedWriteProgressLogDecorator", () => {
         await log.flush();
 
         assert.deepEqual(delegateLog.logList, [
-            "I'm a lumberjack and I'm OK",
+            "I'm a lumberjack and I'm OK\n",
             "I sleep all night and I work all day",
         ]);
     });

--- a/test/api-helper/log/LoggingProgressLogTest.ts
+++ b/test/api-helper/log/LoggingProgressLogTest.ts
@@ -1,0 +1,16 @@
+import { LoggingProgressLog } from "../../../src/api-helper/log/LoggingProgressLog";
+import *  as assert from "assert";
+
+describe("The logging progress logger", () => {
+
+    it("remembers the log accurately", () => {
+        const progressLog = new LoggingProgressLog("hi", "debug");
+        const input = [`I am some stuff
+that might get written to the log
+and so on
+`, "and so on and so on\n"];
+        input.forEach(line => progressLog.write(line));
+
+        assert.strictEqual(progressLog.log, input.join(""));
+    });
+});

--- a/test/api-helper/log/LoggingProgressLogTest.ts
+++ b/test/api-helper/log/LoggingProgressLogTest.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { LoggingProgressLog } from "../../../src/api-helper/log/LoggingProgressLog";
 import *  as assert from "assert";
 


### PR DESCRIPTION
The DelimitedWrite progress log decorator postpones writes until the end of a line.

It should still pass on the delimiter though!

This was causing the build logs to all be one line when analyzed for slack messaging, which made them unparsable.

Please can we have the newlines back downstream.