### PR TITLE
Add builder option for declaring command parameters

### DIFF
--- a/src/api/registration/CommandRegistration.ts
+++ b/src/api/registration/CommandRegistration.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { BaseParameter } from "@atomist/automation-client/internal/metadata/decoratorSupport";
 import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 
@@ -26,9 +27,101 @@ export interface CommandRegistration<PARAMS> extends Partial<CommandDetails> {
     name: string;
 
     /**
-     * Create the parameters required by this command.
+     * Function to create a parameters object used by this command.
      * Empty parameters will be returned by default.
      */
     paramsMaker?: Maker<PARAMS>;
 
+    /**
+     * Define parameters used by this command. Alternative to using
+     * paramsMaker: Do not supply both.
+     */
+    paramsBuilder?: ParametersBuilder;
+
+}
+
+/**
+ * Fluent builder for parameters
+ */
+export class ParametersBuilder {
+
+    public readonly parameters: NamedParameter[] = [];
+    public readonly mappedParameters: NamedMappedParameter[] = [];
+    public readonly secrets: NamedSecret[] = [];
+
+    /**
+     * Declare a new parameter for a command
+     * @param {NamedParameter} p
+     * @return {this}
+     */
+    public addParameter(p: NamedParameter): this {
+        this.parameters.push(p);
+        return this;
+    }
+
+    /**
+     * Declare a new mapped parameter for a command
+     * @param {NamedMappedParameter} mp
+     * @return {this}
+     */
+    public addMappedParameter(mp: NamedMappedParameter): this {
+        this.mappedParameters.push(mp);
+        return this;
+    }
+
+    /**
+     * Declare a new secret for a command
+     * @param {NamedSecret} s
+     * @return {this}
+     */
+    public addSecret(s: NamedSecret): this {
+        this.secrets.push(s);
+        return this;
+    }
+}
+
+export type NamedParameter = BaseParameter & { name: string };
+
+export interface NamedSecret {
+    name: string;
+    uri: string;
+}
+
+export interface NamedMappedParameter {
+    name: string;
+    uri: string;
+    required?: boolean;
+}
+
+/**
+ * Declare a new parameter for the given command
+ * @param {NamedParameter} p
+ * @return {ParametersBuilder}
+ */
+export function addParameter(p: NamedParameter): ParametersBuilder {
+    const pb = new ParametersBuilder();
+    pb.parameters.push(p);
+    return pb;
+}
+
+/**
+ * Declare a new mapped parameter for the given command
+ * @param {NamedMappedParameter} p
+ * @return {ParametersBuilder}
+ */
+export function addMappedParameter(p: NamedMappedParameter): ParametersBuilder {
+    const pb = new ParametersBuilder();
+    pb.mappedParameters.push(p);
+    return pb;
+}
+
+/**
+ * Declare a new secret for the given command
+ * @param {NamedSecret} s
+ * @return {ParametersBuilder}
+ */
+export function addSecret(s: NamedSecret): ParametersBuilder {
+    const pb = new ParametersBuilder();
+    pb.secrets.push(s);
+    return pb;
 }

--- a/src/api/registration/GeneratorRegistration.ts
+++ b/src/api/registration/GeneratorRegistration.ts
@@ -22,8 +22,9 @@ import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
 /**
  * Register a project creation operation
  */
-export interface GeneratorRegistration<PARAMS extends SeedDrivenGeneratorParameters> extends Partial<GeneratorCommandDetails<PARAMS>>,
-    ProjectOperationRegistration<PARAMS> {
+export interface GeneratorRegistration<PARAMS extends SeedDrivenGeneratorParameters = SeedDrivenGeneratorParameters>
+    extends Partial<GeneratorCommandDetails<PARAMS>>,
+        ProjectOperationRegistration<PARAMS> {
 
     /**
      * Create the parameters required by this generator

--- a/test/api/registration/commandRegistrationTest.ts
+++ b/test/api/registration/commandRegistrationTest.ts
@@ -1,0 +1,151 @@
+import { SelfDescribingHandleCommand } from "@atomist/automation-client/HandleCommand";
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { toFactory } from "@atomist/automation-client/util/constructionUtils";
+import * as assert from "power-assert";
+import {
+    commandHandlerRegistrationToCommand,
+    editorRegistrationToCommand,
+    generatorRegistrationToCommand,
+} from "../../../src/api-helper/machine/handlerRegistrations";
+import { SeedDrivenGeneratorParametersSupport } from "../../../src/api/command/generator/SeedDrivenGeneratorParametersSupport";
+import { CommandHandlerRegistration } from "../../../src/api/registration/CommandHandlerRegistration";
+import { addParameter } from "../../../src/api/registration/CommandRegistration";
+import { EditorRegistration } from "../../../src/api/registration/EditorRegistration";
+import { GeneratorRegistration } from "../../../src/api/registration/GeneratorRegistration";
+
+describe("command registrations", () => {
+
+    it("parameter builder should set parameters", () => {
+        const reg: CommandHandlerRegistration<{ foo: string, bar: string }> = {
+            name: "test",
+            paramsBuilder:
+                addParameter({name: "foo"})
+                    .addParameter({name: "bar", required: true}),
+            listener: async ci => {
+                return ci.addressChannels(ci.parameters.foo + ci.parameters.bar);
+            },
+        };
+        const maker = commandHandlerRegistrationToCommand(null, reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        assert.equal(instance.parameters.length, 2);
+        const pi = instance.freshParametersInstance();
+        pi.name = "foo";
+        assert.equal(pi.name, "foo");
+    });
+
+    it("parameter builder should set mapped parameters", () => {
+        const reg: CommandHandlerRegistration = {
+            name: "test",
+            paramsBuilder:
+                addParameter({name: "foo"})
+                    .addParameter({name: "bar", required: true})
+                    .addMappedParameter({name: "x", uri: "http://thing"}),
+            listener: async ci => {
+                return ci.addressChannels(ci.parameters.foo + ci.parameters.bar);
+            },
+        };
+        const maker = commandHandlerRegistrationToCommand(null, reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        assert.equal(instance.parameters.length, 2);
+        assert.equal(instance.mapped_parameters.length, 1);
+        const pi = instance.freshParametersInstance();
+        pi.name = "foo";
+        assert.equal(pi.name, "foo");
+    });
+
+    it("parameter builder should set secret", () => {
+        const reg: CommandHandlerRegistration = {
+            name: "test",
+            paramsBuilder:
+                addParameter({name: "foo"})
+                    .addParameter({name: "bar", required: true})
+                    .addSecret({name: "x", uri: "http://thing"}),
+            listener: async ci => {
+                return ci.addressChannels(ci.parameters.foo + ci.parameters.bar);
+            },
+        };
+        const maker = commandHandlerRegistrationToCommand(null, reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        assert.equal(instance.parameters.length, 2);
+        assert.equal(instance.secrets.length, 1);
+        const pi = instance.freshParametersInstance();
+        pi.name = "foo";
+        assert.equal(pi.name, "foo");
+    });
+
+    it("should combine builder and maker", () => {
+        const reg: CommandHandlerRegistration = {
+            name: "test",
+            paramsMaker: () => new SeedDrivenGeneratorParametersSupport({seed: () => new GitHubRepoRef("a", "b")}),
+            paramsBuilder:
+                addParameter({name: "foo"})
+                    .addParameter({name: "bar", required: true}),
+            listener: async ci => {
+                return ci.addressChannels(ci.parameters.foo + ci.parameters.bar);
+            },
+        };
+        const maker = commandHandlerRegistrationToCommand(null, reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        assert(instance.parameters.some(p => p.name === "foo"));
+        assert(instance.parameters.some(p => p.name === "target.repo"));
+        const pi = instance.freshParametersInstance();
+        pi.name = "foo";
+        assert.equal(pi.name, "foo");
+    });
+
+    it("should build on generator", () => {
+        const reg: GeneratorRegistration = {
+            name: "test",
+            paramsMaker: () => new SeedDrivenGeneratorParametersSupport({seed: () => new GitHubRepoRef("a", "b")}),
+            paramsBuilder:
+                addParameter({name: "foo"})
+                    .addParameter({name: "bar", required: true}),
+            editor: async p => p,
+        };
+        const maker = generatorRegistrationToCommand({
+            artifactStore: null,
+            name: "test",
+            repoRefResolver: null,
+            projectLoader: null,
+            logFactory: null,
+            repoFinder: null,
+            projectPersister: null,
+            credentialsResolver: null,
+        }, reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        assert(instance.parameters.some(p => p.name === "foo"));
+        assert(instance.parameters.some(p => p.name === "target.repo"));
+        const pi = instance.freshParametersInstance();
+        pi.name = "foo";
+        assert.equal(pi.name, "foo");
+    });
+
+    it("should build on generator", () => {
+        const reg: EditorRegistration = {
+            name: "test",
+            paramsMaker: () => new SeedDrivenGeneratorParametersSupport({seed: () => new GitHubRepoRef("a", "b")}),
+            paramsBuilder:
+                addParameter({name: "foo"})
+                    .addParameter({name: "bar", required: true}),
+            editor: async p => p,
+        };
+        const maker = editorRegistrationToCommand({
+            artifactStore: null,
+            name: "test",
+            repoRefResolver: null,
+            projectLoader: null,
+            logFactory: null,
+            repoFinder: null,
+            projectPersister: null,
+            credentialsResolver: null,
+        }, reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        assert(instance.parameters.some(p => p.name === "foo"));
+        // From common
+        assert(instance.parameters.some(p => p.name === "targets.repos"));
+        const pi = instance.freshParametersInstance();
+        pi.name = "foo";
+        assert.equal(pi.name, "foo");
+    });
+
+});

--- a/test/api/registration/commandRegistrationTest.ts
+++ b/test/api/registration/commandRegistrationTest.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { SelfDescribingHandleCommand } from "@atomist/automation-client/HandleCommand";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { toFactory } from "@atomist/automation-client/util/constructionUtils";


### PR DESCRIPTION
Backward compatible. Adds a builder option for parameter declaration. Allow parameters to be added to existing decorated parameter classes, or either approach used on its own.