### PR TITLE
Do not memoize pre-emptively

### DIFF
--- a/src/api/mapping/support/PushRule.ts
+++ b/src/api/mapping/support/PushRule.ts
@@ -43,7 +43,7 @@ export class PushRule<V = any> implements StaticPushMapping<V> {
     private reason: string;
 
     constructor(protected guard1: PushTest, protected guards: PushTest[], reason?: string) {
-        this.pushTest = allSatisfied(memoize(guard1), ...guards.map(memoize));
+        this.pushTest = allSatisfied(guard1, ...guards);
         this.reason = reason || this.pushTest.name;
     }
 

--- a/src/api/mapping/support/PushRule.ts
+++ b/src/api/mapping/support/PushRule.ts
@@ -19,7 +19,6 @@ import { PushListenerInvocation } from "../../listener/PushListener";
 import { PushTest } from "../PushTest";
 import {
     allSatisfied,
-    memoize,
 } from "./pushTestUtils";
 import { StaticPushMapping } from "./StaticPushMapping";
 

--- a/src/api/mapping/support/pushTestUtils.ts
+++ b/src/api/mapping/support/pushTestUtils.ts
@@ -58,7 +58,9 @@ export function anySatisfied(...pushTests: PushTestOrProjectPredicate[]): PushTe
 const pushTestResultMemory = new LruCache<boolean>(1000);
 
 /**
- * Cache the PushTest results for this push
+ * Cache the PushTest results for this push. The results will be cached based
+ * on the name of the pushTest and the ID of the push. Make sure your push test
+ * has a unique name!
  * @param {PushTest} pt
  * @return {PushTest}
  */


### PR DESCRIPTION
This causes very subtle bugs when people happen to name different tests with the same name.
If we have an expensive pushTest, people can memoize it explicitly.