### PR TITLE
Autofixes can use many transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Rename "editor" to "codeTransform" for clarity. [#424](https://github.com/atomist/sdm/issues/424)
 -   **BREAKING** `onAnyPush` becomes a function to avoid side effects.
--   **BREAKING** `CodeTransform` is now an alias for `SimpleProjectEditor` to make the commonest 
-case natural. Use `CodeTransformRegisterable` to return an `EditResult`.
+-   **BREAKING** `CodeTransform` is now an alias for `SimpleProjectEditor` to make the commonest case natural. Use `CodeTransformRegisterable` to return an `EditResult`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Rename "editor" to "codeTransform" for clarity. [#424](https://github.com/atomist/sdm/issues/424)
 -   **BREAKING** `onAnyPush` becomes a function to avoid side effects.
+-   **BREAKING** `CodeTransform` is now an alias for `SimpleProjectEditor` to make the commonest 
+case natural. Use `CodeTransformRegisterable` to return an `EditResult`.
 
 ### Added
 

--- a/src/api-helper/command/editor/localCommandsCodeTransform.ts
+++ b/src/api-helper/command/editor/localCommandsCodeTransform.ts
@@ -16,14 +16,9 @@
 
 import { logger } from "@atomist/automation-client";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
-import {
-    ChildProcessResult,
-    spawnAndWatch,
-    SpawnCommand,
-    stringifySpawnCommand,
-} from "@atomist/automation-client/util/spawned";
+import { ChildProcessResult, spawnAndWatch, SpawnCommand, stringifySpawnCommand, } from "@atomist/automation-client/util/spawned";
 import { SpawnOptions } from "child_process";
-import { CodeTransform } from "../../../api/registration/ProjectOperationRegistration";
+import { CodeTransformRegisterable } from "../../../api/registration/ProjectOperationRegistration";
 import { ProgressLog } from "../../../spi/log/ProgressLog";
 import { LoggingProgressLog } from "../../log/LoggingProgressLog";
 
@@ -35,7 +30,7 @@ import { LoggingProgressLog } from "../../log/LoggingProgressLog";
  * @return {ProjectEditor}
  */
 export function localCommandsCodeTransform(commands: SpawnCommand[],
-                                           log: ProgressLog = new LoggingProgressLog("commands")): CodeTransform {
+                                           log: ProgressLog = new LoggingProgressLog("commands")): CodeTransformRegisterable {
     return async (p: GitProject) => {
         const opts: SpawnOptions = {
             cwd: p.baseDir,

--- a/src/api-helper/command/editor/localCommandsCodeTransform.ts
+++ b/src/api-helper/command/editor/localCommandsCodeTransform.ts
@@ -16,7 +16,7 @@
 
 import { logger } from "@atomist/automation-client";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
-import { ChildProcessResult, spawnAndWatch, SpawnCommand, stringifySpawnCommand, } from "@atomist/automation-client/util/spawned";
+import { ChildProcessResult, spawnAndWatch, SpawnCommand, stringifySpawnCommand } from "@atomist/automation-client/util/spawned";
 import { SpawnOptions } from "child_process";
 import { CodeTransformRegisterable } from "../../../api/registration/ProjectOperationRegistration";
 import { ProgressLog } from "../../../spi/log/ProgressLog";

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -50,7 +50,7 @@ import {
     ParametersListing,
 } from "../../api/registration/ParametersDefinition";
 import {
-    CodeTransform,
+    CodeTransform, CodeTransformRegisterable,
     ProjectOperationRegistration,
 } from "../../api/registration/ProjectOperationRegistration";
 import { createCommand } from "../command/createCommand";
@@ -136,11 +136,11 @@ export function eventHandlerRegistrationToEvent(sdm: MachineOrMachineOptions, e:
     );
 }
 
-function toCodeTransformFunction<PARAMS>(por: ProjectOperationRegistration<PARAMS>): (params: PARAMS) => CodeTransform<PARAMS> {
+function toCodeTransformFunction<PARAMS>(por: ProjectOperationRegistration<PARAMS>): (params: PARAMS) => CodeTransformRegisterable<PARAMS> {
     por.transform = por.transform || por.editor;
     if (!!por.transform) {
         if (Array.isArray(por.transform)) {
-            return () => chainTransforms(...por.transform as Array<CodeTransform<PARAMS>>);
+            return () => chainTransforms(...por.transform as Array<CodeTransformRegisterable<PARAMS>>);
         } else {
             return () => por.transform as CodeTransform<PARAMS>;
         }

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -14,17 +14,8 @@
  * limitations under the License.
  */
 
-import {
-    HandleCommand,
-    HandleEvent,
-    logger,
-    Success,
-} from "@atomist/automation-client";
-import {
-    declareMappedParameter,
-    declareParameter,
-    declareSecret,
-} from "@atomist/automation-client/internal/metadata/decoratorSupport";
+import { HandleCommand, HandleEvent, logger, Success } from "@atomist/automation-client";
+import { declareMappedParameter, declareParameter, declareSecret } from "@atomist/automation-client/internal/metadata/decoratorSupport";
 import { OnCommand } from "@atomist/automation-client/onCommand";
 import { eventHandlerFrom } from "@atomist/automation-client/onEvent";
 import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
@@ -32,13 +23,10 @@ import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitH
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { isProject } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
-import {
-    Maker,
-    toFactory,
-} from "@atomist/automation-client/util/constructionUtils";
+import { Maker, toFactory } from "@atomist/automation-client/util/constructionUtils";
 import { SeedDrivenGeneratorParametersSupport } from "../../api/command/generator/SeedDrivenGeneratorParametersSupport";
 import { CommandListenerInvocation } from "../../api/listener/CommandListener";
-import { chainTransforms, CodeTransformRegistration } from "../../api/registration/CodeTransformRegistration";
+import { CodeTransformRegistration } from "../../api/registration/CodeTransformRegistration";
 import { CommandHandlerRegistration } from "../../api/registration/CommandHandlerRegistration";
 import { EventHandlerRegistration } from "../../api/registration/EventHandlerRegistration";
 import { GeneratorRegistration } from "../../api/registration/GeneratorRegistration";
@@ -50,16 +38,14 @@ import {
     ParametersListing,
 } from "../../api/registration/ParametersDefinition";
 import {
-    CodeTransform, CodeTransformRegisterable,
+    CodeTransformRegisterable,
     ProjectOperationRegistration,
+    toCodeTransformRegisterable,
 } from "../../api/registration/ProjectOperationRegistration";
 import { createCommand } from "../command/createCommand";
 import { editorCommand } from "../command/editor/editorCommand";
 import { generatorCommand } from "../command/generator/generatorCommand";
-import {
-    MachineOrMachineOptions,
-    toMachineOptions,
-} from "./toMachineOptions";
+import { MachineOrMachineOptions, toMachineOptions } from "./toMachineOptions";
 
 export const GeneratorTag = "generator";
 export const TransformTag = "transform";
@@ -139,11 +125,7 @@ export function eventHandlerRegistrationToEvent(sdm: MachineOrMachineOptions, e:
 function toCodeTransformFunction<PARAMS>(por: ProjectOperationRegistration<PARAMS>): (params: PARAMS) => CodeTransformRegisterable<PARAMS> {
     por.transform = por.transform || por.editor;
     if (!!por.transform) {
-        if (Array.isArray(por.transform)) {
-            return () => chainTransforms(...por.transform as Array<CodeTransformRegisterable<PARAMS>>);
-        } else {
-            return () => por.transform as CodeTransform<PARAMS>;
-        }
+        return () => toCodeTransformRegisterable(por.transform);
     }
     por.createTransform = por.createTransform || por.createEditor;
     if (!!por.createTransform) {

--- a/src/api/registration/AutofixRegistration.ts
+++ b/src/api/registration/AutofixRegistration.ts
@@ -15,15 +15,9 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import {
-    EditResult,
-    toEditor,
-} from "@atomist/automation-client/operations/edit/projectEditor";
-import { CodeTransform } from "./ProjectOperationRegistration";
-import {
-    PushReactionRegistration,
-    SelectiveCodeActionOptions,
-} from "./PushReactionRegistration";
+import { EditResult, toEditor, } from "@atomist/automation-client/operations/edit/projectEditor";
+import { CodeTransform, CodeTransformRegisterable } from "./ProjectOperationRegistration";
+import { PushReactionRegistration, SelectiveCodeActionOptions, } from "./PushReactionRegistration";
 import { PushSelector } from "./PushRegistration";
 
 export interface AutofixRegistrationOptions extends SelectiveCodeActionOptions {
@@ -40,12 +34,12 @@ export interface AutofixRegistration extends PushReactionRegistration<EditResult
 export interface CodeTransformAutofixRegistration extends PushSelector {
 
     // TODO will be required when editor is removed
-    transform?: CodeTransform;
+    transform?: CodeTransformRegisterable;
 
     /**
      * @deprecated use transform
      */
-    editor?: CodeTransform;
+    editor?: CodeTransformRegisterable;
 
     options?: AutofixRegistrationOptions;
 

--- a/src/api/registration/AutofixRegistration.ts
+++ b/src/api/registration/AutofixRegistration.ts
@@ -15,9 +15,9 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import { EditResult, toEditor, } from "@atomist/automation-client/operations/edit/projectEditor";
-import { CodeTransform, CodeTransformRegisterable } from "./ProjectOperationRegistration";
-import { PushReactionRegistration, SelectiveCodeActionOptions, } from "./PushReactionRegistration";
+import { EditResult, toEditor } from "@atomist/automation-client/operations/edit/projectEditor";
+import { CodeTransformOrTransforms, CodeTransformRegisterable, toCodeTransformRegisterable } from "./ProjectOperationRegistration";
+import { PushReactionRegistration, SelectiveCodeActionOptions } from "./PushReactionRegistration";
 import { PushSelector } from "./PushRegistration";
 
 export interface AutofixRegistrationOptions extends SelectiveCodeActionOptions {
@@ -34,7 +34,7 @@ export interface AutofixRegistration extends PushReactionRegistration<EditResult
 export interface CodeTransformAutofixRegistration extends PushSelector {
 
     // TODO will be required when editor is removed
-    transform?: CodeTransformRegisterable;
+    transform?: CodeTransformOrTransforms<any>;
 
     /**
      * @deprecated use transform
@@ -67,7 +67,7 @@ export type EditorAutofixRegistration = CodeTransformAutofixRegistration;
  * do not support respond. Be sure to set parameters if they are required by your transform.
  */
 export function toAutofixRegistration(use: CodeTransformAutofixRegistration): AutofixRegistration {
-    const transformToUse = toEditor(use.transform || use.editor);
+    const transformToUse = toEditor(toCodeTransformRegisterable(use.transform || use.editor));
     return {
         name: use.name,
         pushTest: use.pushTest,

--- a/src/api/registration/ProjectOperationRegistration.ts
+++ b/src/api/registration/ProjectOperationRegistration.ts
@@ -15,6 +15,7 @@
  */
 
 import { AnyProjectEditor, SimpleProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
+import { chainTransforms } from "./CodeTransformRegistration";
 import { CommandRegistration } from "./CommandRegistration";
 
 /**
@@ -23,6 +24,19 @@ import { CommandRegistration } from "./CommandRegistration";
 export type CodeTransform<P = any> = SimpleProjectEditor<P>;
 
 export type CodeTransformRegisterable<P = any> = AnyProjectEditor<P>;
+
+/**
+ * One or many CodeTransforms
+ */
+export type CodeTransformOrTransforms<PARAMS> = CodeTransformRegisterable<PARAMS> | Array<CodeTransformRegisterable<PARAMS>>;
+
+export function toCodeTransformRegisterable<PARAMS>(ctot: CodeTransformOrTransforms<PARAMS>): CodeTransformRegisterable<PARAMS> {
+    if (Array.isArray(ctot)) {
+        return chainTransforms(...ctot);
+    } else {
+        return ctot as CodeTransform<PARAMS>;
+    }
+}
 
 /**
  * Superclass for all registrations of "project operations",
@@ -34,7 +48,7 @@ export interface ProjectOperationRegistration<PARAMS> extends CommandRegistratio
     /**
      * Function to transform the project
      */
-    transform?: CodeTransformRegisterable<PARAMS> | Array<CodeTransformRegisterable<PARAMS>>;
+    transform?: CodeTransformOrTransforms<PARAMS>;
 
     /**
      * Create the editor function that can modify a project

--- a/src/api/registration/ProjectOperationRegistration.ts
+++ b/src/api/registration/ProjectOperationRegistration.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import { AnyProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
+import { AnyProjectEditor, SimpleProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { CommandRegistration } from "./CommandRegistration";
 
 /**
  * Function that can transform a project
  */
-export type CodeTransform<P = any> = AnyProjectEditor<P>;
+export type CodeTransform<P = any> = SimpleProjectEditor<P>;
+
+export type CodeTransformRegisterable<P = any> = AnyProjectEditor<P>;
 
 /**
  * Superclass for all registrations of "project operations",
@@ -32,7 +34,7 @@ export interface ProjectOperationRegistration<PARAMS> extends CommandRegistratio
     /**
      * Function to transform the project
      */
-    transform?: CodeTransform<PARAMS> | Array<CodeTransform<PARAMS>>;
+    transform?: CodeTransformRegisterable<PARAMS> | Array<CodeTransformRegisterable<PARAMS>>;
 
     /**
      * Create the editor function that can modify a project


### PR DESCRIPTION
- `CodeTransform` defaults to `SimpleProjectEditor`, the commonest case
- Autofixes can use multiple transforms to be consistent with transform and generator registrations