### PR TITLE
Generators no longer require base parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Rename "editor" to "codeTransform" for clarity. [#424](https://github.com/atomist/sdm/issues/424)
 -   **BREAKING** `onAnyPush` becomes a function to avoid side effects.
 -   **BREAKING** `CodeTransform` is now an alias for `SimpleProjectEditor` to make the commonest case natural. Use `CodeTransformRegisterable` to return an `EditResult`.
+-   Generators can now have parameter types that don't extend `SeedDrivenGeneratorParameters`, as this will be mixed in.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -915,7 +915,7 @@
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": false,
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
@@ -4891,7 +4891,7 @@
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": false,
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -5102,7 +5102,7 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": false,
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
@@ -9216,7 +9216,7 @@
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "resolved": false,
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "^1.0.0"
@@ -10177,7 +10177,7 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": false,
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supervisor": {

--- a/src/api-helper/command/generator/generatorCommand.ts
+++ b/src/api-helper/command/generator/generatorCommand.ts
@@ -91,10 +91,11 @@ function toGeneratorParametersMaker<PARAMS>(paramsMaker: Maker<PARAMS>,
     return isSeedDrivenGeneratorParameters(sampleParams) ?
         paramsMaker as Maker<SeedDrivenGeneratorParameters & PARAMS> as any :
         () => {
-            // This way we won't bother with source
+            // This way we won't bother with source, but rely on startingPoint
             const rawParms: PARAMS = toFactory(paramsMaker)();
             const allParms = rawParms as SeedDrivenGeneratorParameters & PARAMS;
             allParms.target = target;
+            allParms.addAtomistWebhook = allParms.addAtomistWebhook || false;
             return allParms;
         };
 }

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -96,6 +96,7 @@ export function generatorRegistrationToCommand(sdm: MachineOrMachineOptions, e: 
         toCodeTransformFunction(e),
         e.name,
         e.paramsMaker,
+        e.fallbackTarget,
         e.startingPoint,
         e,
     );

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -80,10 +80,10 @@ function tagWith(e: Partial<CommandDetails>, tag: string) {
     }
 }
 
-export function generatorRegistrationToCommand(sdm: MachineOrMachineOptions, e: GeneratorRegistration<any>): Maker<HandleCommand> {
+export function generatorRegistrationToCommand<P = any>(sdm: MachineOrMachineOptions, e: GeneratorRegistration<P>): Maker<HandleCommand<P>> {
     tagWith(e, GeneratorTag);
     if (!e.paramsMaker) {
-        e.paramsMaker = NoParameters;
+        e.paramsMaker = NoParameters as any as Maker<P>;
     }
     if (e.startingPoint && isProject(e.startingPoint) && !e.startingPoint.id) {
         // TODO should probably be handled in automation-client
@@ -101,7 +101,8 @@ export function generatorRegistrationToCommand(sdm: MachineOrMachineOptions, e: 
     );
 }
 
-export function commandHandlerRegistrationToCommand(sdm: MachineOrMachineOptions, c: CommandHandlerRegistration<any>): Maker<HandleCommand> {
+export function commandHandlerRegistrationToCommand<P = any>(sdm: MachineOrMachineOptions,
+                                                             c: CommandHandlerRegistration<P>): Maker<HandleCommand<P>> {
     return () => createCommand(
         sdm,
         toOnCommand(c),
@@ -182,8 +183,10 @@ function addParametersDefinedInBuilder<PARAMS>(c: CommandHandlerRegistration<PAR
                 paramsInstance.__kind = "command-handler";
             }
             const paramListing = toParametersListing(c.parameters);
-            paramListing.parameters.forEach(p =>
-                declareParameter(paramsInstance, p.name, p));
+            paramListing.parameters.forEach(p => {
+                paramsInstance[p.name] = p.defaultValue;
+                declareParameter(paramsInstance, p.name, p);
+            });
             paramListing.mappedParameters.forEach(p =>
                 declareMappedParameter(paramsInstance, p.name, p.uri, p.required));
             paramListing.secrets.forEach(p =>

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -24,7 +24,6 @@ import { RemoteRepoRef } from "@atomist/automation-client/operations/common/Repo
 import { isProject } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { Maker, toFactory } from "@atomist/automation-client/util/constructionUtils";
-import { SeedDrivenGeneratorParametersSupport } from "../../api/command/generator/SeedDrivenGeneratorParametersSupport";
 import { CommandListenerInvocation } from "../../api/listener/CommandListener";
 import { CodeTransformRegistration } from "../../api/registration/CodeTransformRegistration";
 import { CommandHandlerRegistration } from "../../api/registration/CommandHandlerRegistration";
@@ -84,7 +83,7 @@ function tagWith(e: Partial<CommandDetails>, tag: string) {
 export function generatorRegistrationToCommand(sdm: MachineOrMachineOptions, e: GeneratorRegistration<any>): Maker<HandleCommand> {
     tagWith(e, GeneratorTag);
     if (!e.paramsMaker) {
-        e.paramsMaker = SeedDrivenGeneratorParametersSupport;
+        e.paramsMaker = NoParameters;
     }
     if (e.startingPoint && isProject(e.startingPoint) && !e.startingPoint.id) {
         // TODO should probably be handled in automation-client

--- a/src/api/registration/CommandHandlerRegistration.ts
+++ b/src/api/registration/CommandHandlerRegistration.ts
@@ -31,6 +31,9 @@ export interface CommandHandlerRegistration<PARAMS = any> extends CommandRegistr
      */
     createCommand?: (sdm: MachineOrMachineOptions) => OnCommand<PARAMS>;
 
+    /**
+     * Callback executing the command
+     */
     listener?: CommandListener<PARAMS>;
 
 }

--- a/src/api/registration/GeneratorRegistration.ts
+++ b/src/api/registration/GeneratorRegistration.ts
@@ -16,8 +16,9 @@
 
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { GeneratorCommandDetails } from "@atomist/automation-client/operations/generate/generatorToCommand";
-import { SeedDrivenGeneratorParameters } from "@atomist/automation-client/operations/generate/SeedDrivenGeneratorParameters";
+import { NewRepoCreationParameters } from "@atomist/automation-client/operations/generate/NewRepoCreationParameters";
 import { Project } from "@atomist/automation-client/project/Project";
+import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
 
 /**
@@ -29,8 +30,8 @@ export type StartingPoint = Project | RemoteRepoRef;
 /**
  * Register a project creation operation
  */
-export interface GeneratorRegistration<PARAMS extends SeedDrivenGeneratorParameters = SeedDrivenGeneratorParameters>
-    extends Partial<GeneratorCommandDetails<PARAMS>>,
+export interface GeneratorRegistration<PARAMS = NoParameters>
+    extends Partial<GeneratorCommandDetails<any>>,
         ProjectOperationRegistration<PARAMS> {
 
     /**
@@ -40,4 +41,9 @@ export interface GeneratorRegistration<PARAMS extends SeedDrivenGeneratorParamet
      */
     startingPoint?: StartingPoint;
 
+    /**
+     * Allow customization of the target for this repo,
+     * e.g. to target a different source control system.
+     */
+    fallbackTarget?: NewRepoCreationParameters;
 }

--- a/src/api/registration/ParametersDefinition.ts
+++ b/src/api/registration/ParametersDefinition.ts
@@ -19,12 +19,18 @@ import { BaseParameter } from "@atomist/automation-client/internal/metadata/deco
 export type ParametersDefinition = ParametersListing | ParametersObject;
 
 /**
+ * Interface mixed in with BaseParameter to allow adding a default value to a parameter.
+ * When the class-style decorated approach is used, this is unnecessary as any field
+ * value will be used as a default.
+ */
+export interface HasDefaultValue { defaultValue?: any; }
+
+/**
  * Object with properties defining parameters. Useful for combination
  * via spreads.
  */
 export interface ParametersObject {
-
-    [name: string]: BaseParameter | MappedParameterOrSecretDeclaration;
+    [name: string]: (BaseParameter & HasDefaultValue) | MappedParameterOrSecretDeclaration;
 }
 
 export enum DeclarationType {
@@ -55,7 +61,7 @@ export interface ParametersListing {
     readonly secrets: NamedSecret[];
 }
 
-export type NamedParameter = BaseParameter & { name: string };
+export type NamedParameter = BaseParameter & { name: string } & HasDefaultValue;
 
 export interface NamedSecret {
     name: string;

--- a/test/api/registration/commandRegistrationTest.ts
+++ b/test/api/registration/commandRegistrationTest.ts
@@ -264,6 +264,7 @@ describe("command registrations", () => {
             "Should have mixed in SeedDrivenGeneratorParameters: had " + JSON.stringify(paramsInstance));
         assert(instance.parameters.some(p => p.name === "foo"));
         assert(instance.parameters.some(p => p.name === "target.repo"));
+        assert(instance.parameters.some(p => p.name === "addAtomistWebhook"));
         const pi = instance.freshParametersInstance();
         pi.name = "foo";
         assert.equal(pi.name, "foo");
@@ -292,6 +293,7 @@ describe("command registrations", () => {
         assert(instance.parameters.some(p => p.name === "foo"));
         // From common
         assert(instance.parameters.some(p => p.name === "targets.repos"));
+        assert(instance.parameters.some(p => p.name === "addAtomistWebhook"));
         const pi = instance.freshParametersInstance();
         pi.name = "foo";
         assert.equal(pi.name, "foo");

--- a/test/api/registration/commandRegistrationTest.ts
+++ b/test/api/registration/commandRegistrationTest.ts
@@ -238,6 +238,22 @@ describe("command registrations", () => {
         assert.equal(pi.name, "foo");
     });
 
+    it("should build on code transform", () => {
+        const reg: CodeTransformRegistration = {
+            name: "test",
+            parameters:
+                addParameters({ name: "foo" })
+                    .addParameters({ name: "bar", required: true }),
+            transform: async p => p,
+        };
+        const maker = codeTransformRegistrationToCommand(new TestSoftwareDeliveryMachine("test"), reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        assert(instance.parameters.some(p => p.name === "foo"));
+        assert(instance.parameters.some(p => p.name === "targets.repos"));
+        const pi = instance.freshParametersInstance();
+        assert(!!pi);
+    });
+
     it("should build on generator", () => {
         const reg: GeneratorRegistration = {
             name: "test",


### PR DESCRIPTION
- It's no longer necessary to specify a type extending `SeedDrivenGeneratorParameters` to create a parameter.  This is consistent with how editor registrations already worked.
- Parameters added using `parameters` property of `CommandRegistration` can have default values.

For example, it's now possible to define a generator like this:

```typescript
sdm.addGeneratorCommand<{param: string}({
            name: "typescript-express-generator",
            startingPoint: new GitHubRepoRef("spring-team", "typescript-express-seed"),
            intent: "create node",
            parameters: {
                  param: { required: false, defaultValue: "thing" },
            },
            transform: [
                UpdatePackageJsonIdentification,
                UpdateReadmeTitle],
        })
```

This change is backward compatible.