### PR TITLE
Add DSL for creating Goals

### DIFF
--- a/src/api/goal/Goals.ts
+++ b/src/api/goal/Goals.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { Goal } from "./Goal";
+import {
+    Goal,
+    GoalWithPrecondition,
+} from "./Goal";
 
 /**
  * Represents goals set in response to a push
@@ -30,4 +33,96 @@ export class Goals {
 
 export function isGoals(a: any): a is Goals {
     return !!(a as Goals).goals;
+}
+
+/**
+ *  Builder to build Goals instances.
+ */
+export interface GoalsBuilder {
+
+    /**
+     * Plan the given goal or goals to this Goals instance.
+     * @param {Goal | Goals} goals
+     * @returns {Goals & GoalsAndPreConditionBuilder}
+     */
+    plan(...goals: Array<Goal | Goals>): Goals & GoalsAndPreConditionBuilder;
+
+}
+
+/**
+ * Extension to GoalsBuilder allowing to add preConditions,
+ */
+export interface GoalsAndPreConditionBuilder extends GoalsBuilder {
+
+    /**
+     * Add preCondition(s) to previously planned goal or goals.
+     * Note:
+     * This only will effect the goal or goals that where planned immediately
+     * before calling after. Additional a call to this method will remove all pre conditions
+     * that may have existed on the original goal.
+     * @param {Goal} goals
+     * @returns {Goals & GoalsBuilder}
+     */
+    after(...goals: Array<Goal>): Goals & GoalsBuilder;
+
+}
+
+/**
+ * Create Goals instance using a fluent API.
+ *
+ *  const simpleGoals = goals("Simple Goals")
+ *     .plan(ReviewGoal)
+ *     .plan(BuildGoal, AutofixGoal).after(ReviewGoal)
+ *     .plan(StagingEndpointGoal).after(BuildGoal)
+ *     .plan(ProductionDeploymentGoal).after(BuildGoal, StagingEndpointGoal);
+ *
+ * @param {string} name
+ * @returns {Goals & GoalsBuilder}
+ */
+export function goals(name: string): Goals & GoalsBuilder {
+    return new DefaultGoalsBuilder(name);
+}
+
+class DefaultGoalsBuilder extends Goals implements GoalsBuilder, GoalsAndPreConditionBuilder {
+
+    private lastGoals: Array<Goal> = [];
+
+    constructor(public name: string) {
+        super(name);
+    }
+
+    public plan(...newGoals: Array<Goal | Goals>): Goals & GoalsAndPreConditionBuilder {
+        const currentGoals = [];
+
+        // Keep track of what goals where last added so that we can add the preConditions later
+        newGoals.forEach(g => {
+            if (isGoals(g)) {
+                currentGoals.push(...g.goals);
+            } else {
+                currentGoals.push(g);
+            }
+        });
+        this.goals.push(...currentGoals);
+        this.lastGoals = currentGoals;
+
+        return this;
+    }
+
+    public after(...newGoals: Array<Goal>): Goals & GoalsBuilder {
+        const lastGoalsWithPreConditions = [];
+
+        this.lastGoals.forEach(g => {
+            // Add the preCondition into the last added goals
+            lastGoalsWithPreConditions.push(new GoalWithPrecondition(g.definition, ...newGoals));
+            // Remove the previously added goals
+            this.goals.splice(this.goals.indexOf(g), 1);
+        });
+
+        // Add the newly created goals with preConditions
+        this.goals.push(...lastGoalsWithPreConditions);
+        this.lastGoals = lastGoalsWithPreConditions;
+
+        return this;
+    }
+
 }

--- a/src/api/goal/Goals.ts
+++ b/src/api/goal/Goals.ts
@@ -115,7 +115,12 @@ class DefaultGoalsBuilder extends Goals implements GoalsBuilder, GoalsAndPreCond
             // Add the preCondition into the last added goals
             lastGoalsWithPreConditions.push(new GoalWithPrecondition(g.definition, ...newGoals));
             // Remove the previously added goals
-            this.goals.splice(this.goals.indexOf(g), 1);
+            const ix = this.goals.indexOf(g);
+            if (ix >= 0) {
+                this.goals.splice(ix, 1);
+            } else {
+                throw new Error("Unable to remove previously planned goal");
+            }
         });
 
         // Add the newly created goals with preConditions

--- a/test/api/goal/GoalsTest.ts
+++ b/test/api/goal/GoalsTest.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import * as assert from "power-assert";
+import {
+    AutofixGoal,
+    BuildGoal,
+    goals,
+    GoalWithPrecondition,
+    ProductionDeploymentGoal,
+    ReviewGoal,
+    StagingEndpointGoal,
+} from "../../../src";
+
+describe("GoalBuilder", () => {
+
+    it("should construct simple goal set", () => {
+        const simpleGoals = goals("Simple Goals")
+            .plan(BuildGoal, AutofixGoal)
+            .plan(StagingEndpointGoal);
+
+        assert.strictEqual(simpleGoals.name, "Simple Goals");
+        assert.strictEqual(simpleGoals.goals.length, 3);
+    });
+
+    it("should construct simple goal set with one pre condition", () => {
+        const simpleGoals = goals("Simple Goals")
+            .plan(BuildGoal, AutofixGoal)
+            .plan(StagingEndpointGoal).after(BuildGoal);
+
+        assert.strictEqual(simpleGoals.name, "Simple Goals");
+        assert.strictEqual(simpleGoals.goals.length, 3);
+
+        const g = (simpleGoals.goals[2] as GoalWithPrecondition);
+
+        assert.strictEqual(g.name, StagingEndpointGoal.name);
+        assert.strictEqual(g.dependsOn.length, 1);
+        assert.strictEqual(g.dependsOn[0].name, BuildGoal.name);
+    });
+
+    it("should construct goal set with pre conditions", () => {
+        const simpleGoals = goals("Simple Goals")
+            .plan(ReviewGoal)
+            .plan(BuildGoal, AutofixGoal).after(ReviewGoal)
+            .plan(StagingEndpointGoal).after(BuildGoal)
+            .plan(ProductionDeploymentGoal).after(BuildGoal, StagingEndpointGoal);
+
+        assert.strictEqual(simpleGoals.name, "Simple Goals");
+        assert.strictEqual(simpleGoals.goals.length, 5);
+
+        const buildGoal = simpleGoals.goals.find(g => g.name === BuildGoal.name) as GoalWithPrecondition;
+        assert.strictEqual(buildGoal.name, BuildGoal.name);
+        assert.strictEqual(buildGoal.dependsOn.length, 1);
+        assert.strictEqual(buildGoal.dependsOn[0].name, ReviewGoal.name);
+
+        const autofixGoal = simpleGoals.goals.find(g => g.name === AutofixGoal.name) as GoalWithPrecondition;
+        assert.strictEqual(autofixGoal.name, AutofixGoal.name);
+        assert.strictEqual(autofixGoal.dependsOn.length, 1);
+        assert.strictEqual(autofixGoal.dependsOn[0].name, ReviewGoal.name);
+
+        const stagingGoal = simpleGoals.goals.find(g => g.name === StagingEndpointGoal.name) as GoalWithPrecondition;
+        assert.strictEqual(stagingGoal.name, StagingEndpointGoal.name);
+        assert.strictEqual(stagingGoal.dependsOn.length, 1);
+        assert.strictEqual(stagingGoal.dependsOn[0].name, BuildGoal.name);
+
+        const prodGoal = simpleGoals.goals.find(g => g.name === ProductionDeploymentGoal.name) as GoalWithPrecondition;
+        assert.strictEqual(prodGoal.name, ProductionDeploymentGoal.name);
+        assert.strictEqual(prodGoal.dependsOn.length, 2);
+        assert.strictEqual(prodGoal.dependsOn[0].name, BuildGoal.name);
+        assert.strictEqual(prodGoal.dependsOn[1].name, StagingEndpointGoal.name);
+    });
+});


### PR DESCRIPTION
This allows to create `Goals` instances without the tedious deconstruction etc:

```
    const StagingDeploymentGoals = goals("Simple Goals")
            .plan(ReviewGoal)
            .plan(BuildGoal, AutofixGoal).after(ReviewGoal)
            .plan(StagingEndpointGoal).after(BuildGoal)
            .plan(ProductionDeploymentGoal).after(BuildGoal, StagingEndpointGoal);
```