### PR TITLE
Add CodeInspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Add DSL for creating Goals. [#437](https://github.com/atomist/sdm/issues/437)
 -   Add "build aware" code transform support. Replaces "dry run" support presently in `sdm-core`.
 -   `CodeTransform` now takes a second argument of type `CommandListenerInvocation` for consistency and to expose more context to transforms
+-   `CodeInspecton` registration to run a non-mutating command against one or more repositories
 
 ## [0.3.1](https://github.com/atomist/sdm/compare/0.3.0...0.3.1) - 2018-07-05
 

--- a/src/api-helper/command/generator/generatorCommand.ts
+++ b/src/api-helper/command/generator/generatorCommand.ts
@@ -14,42 +14,24 @@
  * limitations under the License.
  */
 
-import {
-    HandleCommand,
-    HandlerContext,
-    RedirectResult,
-} from "@atomist/automation-client";
-import {
-    commandHandlerFrom,
-    OnCommand,
-} from "@atomist/automation-client/onCommand";
+import { HandleCommand, HandlerContext, RedirectResult } from "@atomist/automation-client";
+import { commandHandlerFrom, OnCommand } from "@atomist/automation-client/onCommand";
 import { isGitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { RepoLoader } from "@atomist/automation-client/operations/common/repoLoader";
-import {
-    EditorFactory,
-    GeneratorCommandDetails,
-} from "@atomist/automation-client/operations/generate/generatorToCommand";
+import { EditorFactory, GeneratorCommandDetails } from "@atomist/automation-client/operations/generate/generatorToCommand";
 import { generate } from "@atomist/automation-client/operations/generate/generatorUtils";
-import { GitHubRepoCreationParameters } from "@atomist/automation-client/operations/generate/GitHubRepoCreationParameters";
-import { NewRepoCreationParameters } from "@atomist/automation-client/operations/generate/NewRepoCreationParameters";
 import { RepoCreationParameters } from "@atomist/automation-client/operations/generate/RepoCreationParameters";
 import { SeedDrivenGeneratorParameters } from "@atomist/automation-client/operations/generate/SeedDrivenGeneratorParameters";
 import { addAtomistWebhook } from "@atomist/automation-client/operations/generate/support/addAtomistWebhook";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
-import {
-    isProject,
-    Project,
-} from "@atomist/automation-client/project/Project";
+import { isProject, Project } from "@atomist/automation-client/project/Project";
 import { QueryNoCacheOptions } from "@atomist/automation-client/spi/graph/GraphClient";
 import { Maker, toFactory } from "@atomist/automation-client/util/constructionUtils";
 import * as _ from "lodash";
 import { SoftwareDeliveryMachineOptions } from "../../../api/machine/SoftwareDeliveryMachineOptions";
 import { StartingPoint } from "../../../api/registration/GeneratorRegistration";
 import { projectLoaderRepoLoader } from "../../machine/projectLoaderRepoLoader";
-import {
-    MachineOrMachineOptions,
-    toMachineOptions,
-} from "../../machine/toMachineOptions";
+import { MachineOrMachineOptions, toMachineOptions } from "../../machine/toMachineOptions";
 import { CachingProjectLoader } from "../../project/CachingProjectLoader";
 
 /**
@@ -65,7 +47,7 @@ export function generatorCommand<P>(sdm: MachineOrMachineOptions,
                                     editorFactory: EditorFactory<P>,
                                     name: string,
                                     paramsMaker: Maker<P>,
-                                    fallbackTarget: NewRepoCreationParameters,
+                                    fallbackTarget: Maker<RepoCreationParameters>,
                                     startingPoint: StartingPoint,
                                     details: Partial<GeneratorCommandDetails<any>> = {}): HandleCommand {
     const detailsToUse: GeneratorCommandDetails<any> = {
@@ -75,7 +57,7 @@ export function generatorCommand<P>(sdm: MachineOrMachineOptions,
     return commandHandlerFrom(handleGenerate(editorFactory, detailsToUse, startingPoint),
         toGeneratorParametersMaker<P>(
             paramsMaker,
-            fallbackTarget || new GitHubRepoCreationParameters()),
+            toFactory(fallbackTarget)()),
         name,
         detailsToUse.description, detailsToUse.intent, detailsToUse.tags);
 }

--- a/src/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
+++ b/src/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
@@ -43,6 +43,7 @@ import { AnyPush } from "../../api/mapping/support/commonPushTests";
 import { PushRule } from "../../api/mapping/support/PushRule";
 import { PushRules } from "../../api/mapping/support/PushRules";
 import { StaticPushMapping } from "../../api/mapping/support/StaticPushMapping";
+import { CodeInspectionRegistration } from "../../api/registration/CodeInspectionRegistration";
 import { CodeTransformRegistration } from "../../api/registration/CodeTransformRegistration";
 import { CommandHandlerRegistration } from "../../api/registration/CommandHandlerRegistration";
 import { EventHandlerRegistration } from "../../api/registration/EventHandlerRegistration";
@@ -177,6 +178,11 @@ export abstract class AbstractSoftwareDeliveryMachine<O extends SoftwareDelivery
 
     public addCodeTransformCommand<P>(ed: CodeTransformRegistration<P>): this {
         this.registrationManager.addCodeTransformCommand<P>(ed);
+        return this;
+    }
+
+    public addCodeInspectionCommand<R, P>(cir: CodeInspectionRegistration<R, P>): this {
+        this.registrationManager.addCodeInspectionCommand<R, P>(cir);
         return this;
     }
 

--- a/src/api-helper/machine/HandlerRegistrationManagerSupport.ts
+++ b/src/api-helper/machine/HandlerRegistrationManagerSupport.ts
@@ -21,6 +21,7 @@ import {
 import { SeedDrivenGeneratorParameters } from "@atomist/automation-client/operations/generate/SeedDrivenGeneratorParameters";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { CommandRegistrationManager } from "../../api/machine/CommandRegistrationManager";
+import { CodeInspectionRegistration } from "../../api/registration/CodeInspectionRegistration";
 import { CodeTransformRegistration } from "../../api/registration/CodeTransformRegistration";
 import { CommandHandlerRegistration } from "../../api/registration/CommandHandlerRegistration";
 import { EventHandlerRegistration } from "../../api/registration/EventHandlerRegistration";
@@ -29,6 +30,7 @@ import { GeneratorRegistration } from "../../api/registration/GeneratorRegistrat
 import { IngesterRegistration } from "../../api/registration/IngesterRegistration";
 import { IngesterRegistrationManager } from "../../api/registration/IngesterRegistrationManager";
 import {
+    codeInspectionRegistrationToCommand,
     codeTransformRegistrationToCommand,
     commandHandlerRegistrationToCommand,
     eventHandlerRegistrationToEvent,
@@ -70,6 +72,12 @@ export class HandlerRegistrationManagerSupport
 
     public addCodeTransformCommand<P>(ed: CodeTransformRegistration<P>): this {
         const commands = [codeTransformRegistrationToCommand(this.sdm, ed)];
+        this.commandHandlers = this.commandHandlers.concat(commands);
+        return this;
+    }
+
+    public addCodeInspectionCommand<R, P = any>(cir: CodeInspectionRegistration<R, P>): this {
+        const commands = [codeInspectionRegistrationToCommand(this.sdm, cir)];
         this.commandHandlers = this.commandHandlers.concat(commands);
         return this;
     }

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -22,6 +22,7 @@ import { CommandDetails } from "@atomist/automation-client/operations/CommandDet
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { GitHubFallbackReposParameters } from "@atomist/automation-client/operations/common/params/GitHubFallbackReposParameters";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { RepoLoader } from "@atomist/automation-client/operations/common/repoLoader";
 import { doWithAllRepos } from "@atomist/automation-client/operations/common/repoUtils";
 import { AnyProjectEditor, failedEdit, ProjectEditor, successfulEdit } from "@atomist/automation-client/operations/edit/projectEditor";
 import { chainEditors } from "@atomist/automation-client/operations/edit/projectEditorOps";
@@ -51,7 +52,6 @@ import { editorCommand, isTransformParameters, toEditorOrReviewerParametersMaker
 import { generatorCommand, isSeedDrivenGeneratorParameters } from "../command/generator/generatorCommand";
 import { projectLoaderRepoLoader } from "./projectLoaderRepoLoader";
 import { MachineOrMachineOptions, toMachineOptions } from "./toMachineOptions";
-import { RepoLoader } from "@atomist/automation-client/operations/common/repoLoader";
 
 export const GeneratorTag = "generator";
 export const InspectionTag = "inspection";

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -88,7 +88,7 @@ export function codeInspectionRegistrationToCommand<R>(sdm: MachineOrMachineOpti
                 ci.parameters, repoFinder, cir.repoFilter,
                 repoLoader(cir.parameters));
             if (!!cir.react) {
-                await cir.react(results);
+                await cir.react(results, ci);
             } else {
                 logger.info("No react function to react to results of code inspection '%s'", cir.name);
             }

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -21,6 +21,7 @@ import { eventHandlerFrom } from "@atomist/automation-client/onEvent";
 import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { GitHubFallbackReposParameters } from "@atomist/automation-client/operations/common/params/GitHubFallbackReposParameters";
+import { RepoFinder } from "@atomist/automation-client/operations/common/repoFinder";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { RepoLoader } from "@atomist/automation-client/operations/common/repoLoader";
 import { doWithAllRepos } from "@atomist/automation-client/operations/common/repoUtils";
@@ -73,19 +74,23 @@ export function codeTransformRegistrationToCommand(sdm: MachineOrMachineOptions,
 export function codeInspectionRegistrationToCommand<R>(sdm: MachineOrMachineOptions, cir: CodeInspectionRegistration<R, any>): Maker<HandleCommand> {
     tagWith(cir, InspectionTag);
     addParametersDefinedInBuilder(cir);
-    const repoFinder = cir.repoFinder || toMachineOptions(sdm).repoFinder;
+    cir.paramsMaker = toEditorOrReviewerParametersMaker(
+        cir.paramsMaker || NoParameters,
+        cir.targets || new GitHubFallbackReposParameters());
     const asCommand: CommandHandlerRegistration = {
         ...cir as CommandRegistration<any>,
-        paramsMaker: toEditorOrReviewerParametersMaker(
-            cir.paramsMaker || NoParameters,
-            cir.targets || new GitHubFallbackReposParameters()),
         listener: async ci => {
             const action: (p: Project, params: any) => Promise<InspectionResult<R>> = async p => {
                 return { repoId: p.id, result: await cir.inspection(p, ci) };
             };
-            const repoLoader: RepoLoader = cir.repoLoader(ci.parameters) || projectLoaderRepoLoader(
-                toMachineOptions(sdm).projectLoader,
-                ci.parameters.targets.credentials);
+            const repoFinder: RepoFinder = !!ci.parameters.targets.repoRef ?
+                () => Promise.resolve([ci.parameters.targets.repoRef]) :
+                cir.repoFinder || toMachineOptions(sdm).repoFinder;
+            const repoLoader: RepoLoader = !!cir.repoLoader ?
+                cir.repoLoader(ci.parameters) :
+                projectLoaderRepoLoader(
+                    toMachineOptions(sdm).projectLoader,
+                    ci.parameters.targets.credentials);
             const results = await doWithAllRepos<InspectionResult<R>, any>(
                 ci.context,
                 ci.credentials,

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -27,6 +27,7 @@ import { RepoLoader } from "@atomist/automation-client/operations/common/repoLoa
 import { doWithAllRepos } from "@atomist/automation-client/operations/common/repoUtils";
 import { AnyProjectEditor, failedEdit, ProjectEditor, successfulEdit } from "@atomist/automation-client/operations/edit/projectEditor";
 import { chainEditors } from "@atomist/automation-client/operations/edit/projectEditorOps";
+import { GitHubRepoCreationParameters } from "@atomist/automation-client/operations/generate/GitHubRepoCreationParameters";
 import { isProject, Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { Maker, toFactory } from "@atomist/automation-client/util/constructionUtils";
@@ -67,7 +68,7 @@ export function codeTransformRegistrationToCommand(sdm: MachineOrMachineOptions,
         e.name,
         e.paramsMaker,
         e,
-        e.targets || toMachineOptions(sdm).targets,
+        e.targets || toMachineOptions(sdm).targets || GitHubFallbackReposParameters,
     );
 }
 
@@ -76,7 +77,7 @@ export function codeInspectionRegistrationToCommand<R>(sdm: MachineOrMachineOpti
     addParametersDefinedInBuilder(cir);
     cir.paramsMaker = toEditorOrReviewerParametersMaker(
         cir.paramsMaker || NoParameters,
-        cir.targets || new GitHubFallbackReposParameters());
+        cir.targets || GitHubFallbackReposParameters);
     const asCommand: CommandHandlerRegistration = {
         ...cir as CommandRegistration<any>,
         listener: async ci => {
@@ -141,7 +142,7 @@ export function generatorRegistrationToCommand<P = any>(sdm: MachineOrMachineOpt
         toCodeTransformFunction(e),
         e.name,
         e.paramsMaker,
-        e.fallbackTarget,
+        e.fallbackTarget || GitHubRepoCreationParameters,
         e.startingPoint,
         e,
     );

--- a/src/api-helper/test/README.md
+++ b/src/api-helper/test/README.md
@@ -1,0 +1,1 @@
+Useful functions for testing

--- a/src/api-helper/test/fakeCommandListenerInvocation.ts
+++ b/src/api-helper/test/fakeCommandListenerInvocation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import { AddressNoChannels } from "../../api/context/addressChannels";
 import { CommandListenerInvocation } from "../../api/listener/CommandListener";
 import { fakeContext } from "./fakeContext";

--- a/src/api-helper/test/fakeCommandListenerInvocation.ts
+++ b/src/api-helper/test/fakeCommandListenerInvocation.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 import { AddressNoChannels } from "../../api/context/addressChannels";
 import { CommandListenerInvocation } from "../../api/listener/CommandListener";
 import { fakeContext } from "./fakeContext";

--- a/src/api-helper/test/fakeCommandListenerInvocation.ts
+++ b/src/api-helper/test/fakeCommandListenerInvocation.ts
@@ -1,0 +1,14 @@
+import { AddressNoChannels } from "../../api/context/addressChannels";
+import { CommandListenerInvocation } from "../../api/listener/CommandListener";
+import { fakeContext } from "./fakeContext";
+
+export function fakeCommandListenerInvocation<P>(opts: Partial<CommandListenerInvocation> = {}): CommandListenerInvocation {
+    return {
+        commandName: opts.commandName || "test",
+        parameters: opts.parameters,
+        context: fakeContext(),
+        addressChannels: AddressNoChannels,
+        credentials: opts.credentials,
+        ...opts,
+    };
+}

--- a/src/api-helper/test/fakeContext.ts
+++ b/src/api-helper/test/fakeContext.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { HandlerContext } from "@atomist/automation-client";
+import { AutomationContextAware, HandlerContext } from "@atomist/automation-client";
+import { CommandIncoming } from "@atomist/automation-client/internal/transport/RequestProcessor";
 import { Destination, MessageClient, MessageOptions, SlackMessageClient } from "@atomist/automation-client/spi/message/MessageClient";
 import { SlackMessage } from "@atomist/slack-messages";
 
@@ -24,30 +25,42 @@ import { SlackMessage } from "@atomist/slack-messages";
  * @param {string} teamId
  * @return {any}
  */
-export function fakeContext(teamId: string = "T123"): HandlerContext {
+export function fakeContext(teamId: string = "T123"): HandlerContext & AutomationContextAware {
+    const correlationId = "foo";
     return {
         teamId,
         messageClient: new DevNullMessageClient(),
-        correlationId: "foo",
+        correlationId,
+        context: {
+            name: "test-context",
+            teamId,
+            teamName: teamId,
+            operation: "operation",
+            version: "0.1.0",
+            invocationId: "inv-id",
+            ts: new Date().getTime(),
+            correlationId,
+        },
+        trigger: {} as CommandIncoming,
     };
 }
 
 class DevNullMessageClient implements MessageClient, SlackMessageClient {
 
-    public addressChannels(msg: string | SlackMessage, channels: string | string[], options?: MessageOptions): Promise<any> {
-        return undefined;
+    public async addressChannels(msg: string | SlackMessage, channels: string | string[], options?: MessageOptions): Promise<any> {
+        return {};
     }
 
-    public addressUsers(msg: string | SlackMessage, users: string | string[], options?: MessageOptions): Promise<any> {
-        return undefined;
+    public async addressUsers(msg: string | SlackMessage, users: string | string[], options?: MessageOptions): Promise<any> {
+        return {};
     }
 
-    public respond(msg: any, options?: MessageOptions): Promise<any> {
-        return undefined;
+    public async respond(msg: any, options?: MessageOptions): Promise<any> {
+        return {};
     }
 
-    public send(msg: any, destinations: Destination | Destination[], options?: MessageOptions): Promise<any> {
-        return undefined;
+    public async send(msg: any, destinations: Destination | Destination[], options?: MessageOptions): Promise<any> {
+        return {};
     }
 
 }

--- a/src/api-helper/test/fakeContext.ts
+++ b/src/api-helper/test/fakeContext.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import {
-    HandlerContext,
-    logger,
-} from "@atomist/automation-client";
-import * as stringify from "json-stringify-safe";
+import { HandlerContext } from "@atomist/automation-client";
+import { Destination, MessageClient, MessageOptions, SlackMessageClient } from "@atomist/automation-client/spi/message/MessageClient";
+import { SlackMessage } from "@atomist/slack-messages";
 
 /**
  * Convenient function to allow creating fake contexts.
@@ -29,17 +27,27 @@ import * as stringify from "json-stringify-safe";
 export function fakeContext(teamId: string = "T123"): HandlerContext {
     return {
         teamId,
-        messageClient: {
-            respond(m) {
-                logger.info("respond > " + m);
-                return Promise.resolve({});
-            },
-            send(event) {
-                logger.debug("send > " + stringify(event));
-                return Promise.resolve({});
-            },
-        },
+        messageClient: new DevNullMessageClient(),
         correlationId: "foo",
-        context: {name: "fakeContextName", version: "v0.0", operation: "fakeOperation" },
-    } as any as HandlerContext;
+    };
+}
+
+class DevNullMessageClient implements MessageClient, SlackMessageClient {
+
+    public addressChannels(msg: string | SlackMessage, channels: string | string[], options?: MessageOptions): Promise<any> {
+        return undefined;
+    }
+
+    public addressUsers(msg: string | SlackMessage, users: string | string[], options?: MessageOptions): Promise<any> {
+        return undefined;
+    }
+
+    public respond(msg: any, options?: MessageOptions): Promise<any> {
+        return undefined;
+    }
+
+    public send(msg: any, destinations: Destination | Destination[], options?: MessageOptions): Promise<any> {
+        return undefined;
+    }
+
 }

--- a/src/api-helper/test/fakeContext.ts
+++ b/src/api-helper/test/fakeContext.ts
@@ -40,6 +40,7 @@ export function fakeContext(teamId: string = "T123"): HandlerContext & Automatio
             invocationId: "inv-id",
             ts: new Date().getTime(),
             correlationId,
+            messageClient: new DevNullMessageClient(),
         },
         trigger: {} as CommandIncoming,
     };

--- a/src/api-helper/test/fakeGoalInvocation.ts
+++ b/src/api-helper/test/fakeGoalInvocation.ts
@@ -32,7 +32,7 @@ import { fakeContext } from "./fakeContext";
  * @param {RemoteRepoRef} id
  * @return {GoalInvocation}
  */
-export function fakeRunWithLogContext(id: RemoteRepoRef): GoalInvocation {
+export function fakeGoalInvocation(id: RemoteRepoRef): GoalInvocation {
     return {
         credentials: { token: "foobar" },
         context: fakeContext("T1111"),

--- a/src/api-helper/test/fakePush.ts
+++ b/src/api-helper/test/fakePush.ts
@@ -14,14 +14,25 @@
  * limitations under the License.
  */
 
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { GitProject } from "@atomist/automation-client/project/git/GitProject";
 import { Project } from "@atomist/automation-client/project/Project";
+import { AddressNoChannels } from "../../api/context/addressChannels";
 import { PushListenerInvocation } from "../../api/listener/PushListener";
 import { fakeContext } from "./fakeContext";
 
-export function fakePush(project?: Project): PushListenerInvocation {
+export function fakePush(project?: Project, pli: Partial<PushListenerInvocation> = {}): PushListenerInvocation {
     return {
-        push: {id: new Date().getTime() + "_"},
-        project,
+        id: project ? project.id as RemoteRepoRef : new GitHubRepoRef("my", "test"),
+        push: {
+            id: new Date().getTime() + "_",
+            branch: "master",
+        },
+        project: project as GitProject,
         context: fakeContext(),
-    } as any as PushListenerInvocation;
+        addressChannels: AddressNoChannels,
+        credentials: { "fake-token"},
+        ...pli,
+    };
 }

--- a/src/api-helper/test/fakePush.ts
+++ b/src/api-helper/test/fakePush.ts
@@ -32,7 +32,7 @@ export function fakePush(project?: Project, pli: Partial<PushListenerInvocation>
         project: project as GitProject,
         context: fakeContext(),
         addressChannels: AddressNoChannels,
-        credentials: { "fake-token"},
+        credentials: { token: "fake-token" },
         ...pli,
     };
 }

--- a/src/api/machine/CommandRegistrationManager.ts
+++ b/src/api/machine/CommandRegistrationManager.ts
@@ -15,6 +15,7 @@
  */
 
 import { SeedDrivenGeneratorParameters } from "@atomist/automation-client/operations/generate/SeedDrivenGeneratorParameters";
+import { CodeInspectionRegistration } from "../registration/CodeInspectionRegistration";
 import { CodeTransformRegistration } from "../registration/CodeTransformRegistration";
 import { CommandHandlerRegistration } from "../registration/CommandHandlerRegistration";
 import { GeneratorRegistration } from "../registration/GeneratorRegistration";
@@ -47,7 +48,13 @@ export interface CommandRegistrationManager {
      * Add a code transformation to this machine
      * @return {this}
      */
-    addCodeTransformCommand<PARAMS>(ed: CodeTransformRegistration<PARAMS>): this;
+    addCodeTransformCommand<PARAMS>(ctr: CodeTransformRegistration<PARAMS>): this;
+
+    /**
+     * Add a code transformation to this machine
+     * @return {this}
+     */
+    addCodeInspectionCommand<R, PARAMS>(cir: CodeInspectionRegistration<R, PARAMS>): this;
 
     /**
      * @deprecated use add CodeTransformCommand

--- a/src/api/machine/SoftwareDeliveryMachineOptions.ts
+++ b/src/api/machine/SoftwareDeliveryMachineOptions.ts
@@ -21,6 +21,7 @@ import {
 import { FallbackParams } from "@atomist/automation-client/operations/common/params/FallbackParams";
 import { RepoFinder } from "@atomist/automation-client/operations/common/repoFinder";
 import { ProjectPersister } from "@atomist/automation-client/operations/generate/generatorUtils";
+import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { ArtifactStore } from "../../spi/artifact/ArtifactStore";
 import { CredentialsResolver } from "../../spi/credentials/CredentialsResolver";
 import { ProgressLogFactory } from "../../spi/log/ProgressLog";
@@ -74,7 +75,7 @@ export interface SoftwareDeliveryMachineOptions {
      * Allow customization of editor targeting at per-SDM level.
      * If set, can still be overridden by individual editor registrations.
      */
-    targets?: FallbackParams;
+    targets?: Maker<FallbackParams>;
 
 }
 

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -45,8 +45,9 @@ export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
     /**
      * React to computed values from running across one or more projects
      * @param {R[]} results
+     * @param ci context
      * @return {Promise<any>}
      */
-    react?(results: R[]): Promise<any>;
+    react?(results: R[], ci: CommandListenerInvocation<PARAMS>): Promise<any>;
 
 }

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -20,6 +20,7 @@ import { RepoFilter } from "@atomist/automation-client/operations/common/repoFil
 import { RepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
+import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { CommandListenerInvocation } from "../listener/CommandListener";
 import { CommandRegistration } from "./CommandRegistration";
 
@@ -47,7 +48,7 @@ export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
     /**
      * Allow customization of the repositories that an inspection targets.
      */
-    targets?: FallbackParams;
+    targets?: Maker<FallbackParams>;
 
     repoFilter?: RepoFilter;
 

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -17,6 +17,7 @@
 import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
 import { FallbackParams } from "@atomist/automation-client/operations/common/params/FallbackParams";
 import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
+import { RepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { CommandListenerInvocation } from "../listener/CommandListener";
@@ -28,6 +29,14 @@ import { CommandRegistration } from "./CommandRegistration";
  */
 export type CodeInspection<R, P = any> = (p: Project,
                                           sdmc: CommandListenerInvocation<P>) => Promise<R>;
+
+/**
+ * Result of inspecting a single project
+ */
+export interface InspectionResult<R> {
+    repoId: RepoRef;
+    result: R;
+}
 
 export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
     extends Partial<CommandDetails>,
@@ -48,6 +57,6 @@ export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
      * @param ci context
      * @return {Promise<any>}
      */
-    react?(results: R[], ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+    react?(results: Array<InspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
 
 }

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
 import { FallbackParams } from "@atomist/automation-client/operations/common/params/FallbackParams";
 import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -1,0 +1,36 @@
+import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
+import { FallbackParams } from "@atomist/automation-client/operations/common/params/FallbackParams";
+import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
+import { Project } from "@atomist/automation-client/project/Project";
+import { NoParameters } from "@atomist/automation-client/SmartParameters";
+import { CommandListenerInvocation } from "../listener/CommandListener";
+import { CommandRegistration } from "./CommandRegistration";
+
+/**
+ * Function that can run against a project without mutating it to
+ * compute a value.
+ */
+export type CodeInspection<R, P = any> = (p: Project,
+                                          sdmc: CommandListenerInvocation<P>) => Promise<R>;
+
+export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
+    extends Partial<CommandDetails>,
+        CommandRegistration<PARAMS> {
+
+    inspection: CodeInspection<R, PARAMS>;
+
+    /**
+     * Allow customization of the repositories that an inspection targets.
+     */
+    targets?: FallbackParams;
+
+    repoFilter?: RepoFilter;
+
+    /**
+     * React to computed values from running across one or more projects
+     * @param {R[]} results
+     * @return {Promise<any>}
+     */
+    react?(results: R[]): Promise<any>;
+
+}

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -39,6 +39,10 @@ export interface InspectionResult<R> {
     result: R;
 }
 
+/**
+ * Register a CodeInspection that can run against any number of projects.
+ * Include an optional react method that can react to review results.
+ */
 export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
     extends Partial<CommandDetails>,
         CommandRegistration<PARAMS> {

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
 import { FallbackParams } from "@atomist/automation-client/operations/common/params/FallbackParams";
 import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";

--- a/src/api/registration/CodeTransformRegistration.ts
+++ b/src/api/registration/CodeTransformRegistration.ts
@@ -17,6 +17,7 @@
 import { FallbackParams } from "@atomist/automation-client/operations/common/params/FallbackParams";
 import { EditorCommandDetails } from "@atomist/automation-client/operations/edit/editorToCommand";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
+import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
 
 /**
@@ -35,7 +36,7 @@ export interface CodeTransformRegistration<PARAMS = NoParameters>
     /**
      * Allow customization of the repositories a transform targets.
      */
-    targets?: FallbackParams;
+    targets?: Maker<FallbackParams>;
 
 }
 

--- a/src/api/registration/CodeTransformRegistration.ts
+++ b/src/api/registration/CodeTransformRegistration.ts
@@ -33,7 +33,7 @@ export interface CodeTransformRegistration<PARAMS = NoParameters>
         ProjectOperationRegistration<PARAMS> {
 
     /**
-     * Allow customization of the repositories an editor targets.
+     * Allow customization of the repositories a transform targets.
      */
     targets?: FallbackParams;
 

--- a/src/api/registration/GeneratorRegistration.ts
+++ b/src/api/registration/GeneratorRegistration.ts
@@ -16,9 +16,10 @@
 
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { GeneratorCommandDetails } from "@atomist/automation-client/operations/generate/generatorToCommand";
-import { NewRepoCreationParameters } from "@atomist/automation-client/operations/generate/NewRepoCreationParameters";
+import { RepoCreationParameters } from "@atomist/automation-client/operations/generate/RepoCreationParameters";
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
+import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
 
 /**
@@ -45,5 +46,5 @@ export interface GeneratorRegistration<PARAMS = NoParameters>
      * Allow customization of the target for this repo,
      * e.g. to target a different source control system.
      */
-    fallbackTarget?: NewRepoCreationParameters;
+    fallbackTarget?: Maker<RepoCreationParameters>;
 }

--- a/test/api-helper/listener/executeAutofixesTest.ts
+++ b/test/api-helper/listener/executeAutofixesTest.ts
@@ -23,7 +23,7 @@ import { RemoteRepoRef } from "@atomist/automation-client/operations/common/Repo
 import { fileExists } from "@atomist/automation-client/project/util/projectUtils";
 import * as assert from "power-assert";
 import { executeAutofixes } from "../../../src/api-helper/listener/executeAutofixes";
-import { fakeRunWithLogContext } from "../../../src/api-helper/test/fakeRunWithLogContext";
+import { fakeGoalInvocation } from "../../../src/api-helper/test/fakeGoalInvocation";
 import { SingleProjectLoader } from "../../../src/api-helper/test/SingleProjectLoader";
 import { SdmGoal } from "../../../src/api/goal/SdmGoal";
 import { PushListenerInvocation } from "../../../src/api/listener/PushListener";
@@ -93,7 +93,7 @@ describe("executeAutofixes", () => {
         const pl = new SingleProjectLoader({ id } as any);
         const r = await executeAutofixes(pl,
             [],
-            FakeRepoRefResolver)(fakeRunWithLogContext(id));
+            FakeRepoRefResolver)(fakeGoalInvocation(id));
         assert.equal(r.code, 0);
     });
 
@@ -105,7 +105,7 @@ describe("executeAutofixes", () => {
         const pl = new SingleProjectLoader(p);
         const r = await executeAutofixes(pl,
             [AddThingAutofix],
-            FakeRepoRefResolver)(fakeRunWithLogContext(id));
+            FakeRepoRefResolver)(fakeGoalInvocation(id));
         assert.equal(r.code, 0);
         assert.equal(p.findFileSync(f.path).getContentSync(), initialContent);
     });
@@ -120,7 +120,7 @@ describe("executeAutofixes", () => {
         const pl = new SingleProjectLoader(p);
         const r = await executeAutofixes(pl,
             [AddThingAutofix],
-            FakeRepoRefResolver)(fakeRunWithLogContext(id));
+            FakeRepoRefResolver)(fakeGoalInvocation(id));
         assert.equal(r.code, 0);
         assert(!!p);
         const foundFile = p.findFileSync("thing");

--- a/test/api-helper/listener/executePushReactionsTest.ts
+++ b/test/api-helper/listener/executePushReactionsTest.ts
@@ -20,7 +20,7 @@ import { TruePushTest } from "../../api/mapping/support/pushTestUtilsTest";
 
 import * as assert from "power-assert";
 import { executePushReactions } from "../../../src/api-helper/listener/executePushReactions";
-import { fakeRunWithLogContext } from "../../../src/api-helper/test/fakeRunWithLogContext";
+import { fakeGoalInvocation } from "../../../src/api-helper/test/fakeGoalInvocation";
 import { SingleProjectLoader } from "../../../src/api-helper/test/SingleProjectLoader";
 import { PushListenerInvocation } from "../../../src/api/listener/PushListener";
 import { PushReactionRegistration, PushReactionResponse } from "../../../src/api/registration/PushReactionRegistration";
@@ -45,7 +45,7 @@ describe("executePushReactions", () => {
         const p = InMemoryProject.from(id);
         const invocations: PushListenerInvocation[] = [];
         const ge = executePushReactions(new SingleProjectLoader(p), [react(invocations, true)]);
-        const r = await ge(fakeRunWithLogContext(id));
+        const r = await ge(fakeGoalInvocation(id));
         assert.equal(invocations.length, 1);
         assert(!r.requireApproval);
         assert.equal(r.code, 1);
@@ -56,7 +56,7 @@ describe("executePushReactions", () => {
         const p = InMemoryProject.from(id);
         const invocations: PushListenerInvocation[] = [];
         const ge = executePushReactions(new SingleProjectLoader(p), [react(invocations, false)]);
-        const r = await ge(fakeRunWithLogContext(id));
+        const r = await ge(fakeGoalInvocation(id));
         assert.equal(invocations.length, 1);
         assert.equal(r.code, 0);
         assert(!r.requireApproval);

--- a/test/api-helper/listener/executeReviewTest.ts
+++ b/test/api-helper/listener/executeReviewTest.ts
@@ -26,7 +26,7 @@ import { TruePushTest } from "../../api/mapping/support/pushTestUtilsTest";
 import { InMemoryFile } from "@atomist/automation-client/project/mem/InMemoryFile";
 import * as assert from "power-assert";
 import { executeReview } from "../../../src/api-helper/listener/executeReview";
-import { fakeRunWithLogContext } from "../../../src/api-helper/test/fakeRunWithLogContext";
+import { fakeGoalInvocation } from "../../../src/api-helper/test/fakeGoalInvocation";
 import { SingleProjectLoader } from "../../../src/api-helper/test/SingleProjectLoader";
 import { PushReactionResponse } from "../../../src/api/registration/PushReactionRegistration";
 
@@ -87,7 +87,7 @@ describe("executeReview", () => {
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithApproval(reviewEvents);
         const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld], [l]);
-        const r = await ge(fakeRunWithLogContext(id));
+        const r = await ge(fakeGoalInvocation(id));
         assert.equal(r.code, 0);
         assert(!r.requireApproval);
         assert.equal(reviewEvents.length, 1);
@@ -100,7 +100,7 @@ describe("executeReview", () => {
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithApproval(reviewEvents);
         const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld], [l]);
-        const rwlc = fakeRunWithLogContext(id);
+        const rwlc = fakeGoalInvocation(id);
         const r = await ge(rwlc);
         assert.equal(reviewEvents.length, 1);
         assert.equal(reviewEvents[0].review.comments.length, 1);
@@ -115,7 +115,7 @@ describe("executeReview", () => {
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithoutApproval(reviewEvents);
         const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld], [l]);
-        const rwlc = fakeRunWithLogContext(id);
+        const rwlc = fakeGoalInvocation(id);
         const r = await ge(rwlc);
         assert.equal(reviewEvents.length, 1);
         assert.equal(reviewEvents[0].review.comments.length, 1);
@@ -130,7 +130,7 @@ describe("executeReview", () => {
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithApproval(reviewEvents);
         const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld, JustTheOne], [l]);
-        const rwlc = fakeRunWithLogContext(id);
+        const rwlc = fakeGoalInvocation(id);
         const r = await ge(rwlc);
         assert.equal(reviewEvents.length, 1);
         assert.equal(reviewEvents[0].review.comments.length, 2);


### PR DESCRIPTION
- Add `CodeInspection` to run non-mutating functions against repos
- Correct bug affecting all project operation commands where targeting parameters could bleed through into next command