### PR TITLE
Transform command improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   **BREAKING** Remove deprecated `addEditor` SDM method, and deprecated `createTransform` method on `ProjectOperationRegistration`.
 -   **BREAKING** `addPushReaction` renamed `addPushImpactListener` for consistency
 -   **BREAKING** `addNewRepoWithCodeAction` renamed `addNewRepoWithCodeListener` for consistency
+-   **BREAKING**  `CodeTransformRegistration.editMode` is replaced by `transformPresentation`
 
 ### Fixed
 

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -334,8 +334,8 @@ function toProjectEditor<P>(ct: CodeTransform<P>): ProjectEditor<P> {
         const ci = toCommandListenerInvocation(p, ctx, params);
         // Mix in handler context for old style callers
         const r = await ct(p, {
-                ...ci,
                 ...ctx,
+                ...ci,
             } as CommandListenerInvocation<P> & HandlerContext,
             params);
         try {

--- a/src/api/command/target/TransformModeSuggestion.ts
+++ b/src/api/command/target/TransformModeSuggestion.ts
@@ -33,7 +33,7 @@ export interface TransformModeSuggestion {
 
 }
 
-export function isTransformModeSuggestion(p: object): p is TransformModeSuggestion {
+export function isTransformModeSuggestion(p: any): p is TransformModeSuggestion {
     const maybe = p as TransformModeSuggestion;
     return !!maybe.desiredBranchName;
 }

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
 import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
 import { RepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { Project } from "@atomist/automation-client/project/Project";
@@ -44,8 +43,7 @@ export interface InspectionResult<R> {
  * Include an optional react method that can react to review results.
  */
 export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
-    extends Partial<CommandDetails>,
-        CommandRegistration<PARAMS> {
+    extends CommandRegistration<PARAMS> {
 
     inspection: CodeInspection<R, PARAMS>;
 

--- a/src/api/registration/CodeTransformRegistration.ts
+++ b/src/api/registration/CodeTransformRegistration.ts
@@ -15,8 +15,9 @@
  */
 
 import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
-import { EditorCommandDetails } from "@atomist/automation-client/operations/edit/editorToCommand";
+import { EditMode } from "@atomist/automation-client/operations/edit/editModes";
 import { EditResult } from "@atomist/automation-client/operations/edit/projectEditor";
+import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { CommandListenerInvocation } from "../listener/CommandListener";
@@ -28,13 +29,19 @@ import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
  * across projects
  */
 export interface CodeTransformRegistration<PARAMS = NoParameters>
-    extends Partial<EditorCommandDetails>,
-        ProjectOperationRegistration<PARAMS> {
+    extends ProjectOperationRegistration<PARAMS> {
 
     /**
      * Allow customization of the repositories a transform targets.
      */
     targets?: Maker<RepoTargets>;
+
+    /**
+     * How to present the transformation
+     * @param {CommandListenerInvocation<PARAMS>} ci
+     * @return {EditMode}
+     */
+    transformPresentation?: (ci: CommandListenerInvocation<PARAMS>, p: Project) => EditMode;
 
     /**
      * Additionally, programmatically target repositories to transform

--- a/src/api/registration/CommandRegistration.ts
+++ b/src/api/registration/CommandRegistration.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { CommandDetails } from "@atomist/automation-client/operations/CommandDetails";
+import { RepoFinder } from "@atomist/automation-client/operations/common/repoFinder";
+import { RepoLoader } from "@atomist/automation-client/operations/common/repoLoader";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { ParametersDefinition } from "./ParametersDefinition";
 
@@ -22,9 +23,11 @@ import { ParametersDefinition } from "./ParametersDefinition";
  * Type for registering a project transform, which can make changes
  * to projects
  */
-export interface CommandRegistration<PARAMS> extends Partial<CommandDetails> {
+export interface CommandRegistration<PARAMS> {
 
     name: string;
+
+    description?: string;
 
     /**
      * Function to create a parameters object used by this command.
@@ -37,5 +40,12 @@ export interface CommandRegistration<PARAMS> extends Partial<CommandDetails> {
      * paramsMaker: Do not supply both.
      */
     parameters?: ParametersDefinition;
+
+    intent?: string | string[];
+    tags?: string | string[];
+
+    repoFinder?: RepoFinder;
+
+    repoLoader?: (p: PARAMS) => RepoLoader;
 
 }

--- a/src/api/registration/GeneratorRegistration.ts
+++ b/src/api/registration/GeneratorRegistration.ts
@@ -15,7 +15,7 @@
  */
 
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
-import { GeneratorCommandDetails } from "@atomist/automation-client/operations/generate/generatorToCommand";
+import { ProjectPersister } from "@atomist/automation-client/operations/generate/generatorUtils";
 import { RepoCreationParameters } from "@atomist/automation-client/operations/generate/RepoCreationParameters";
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
@@ -32,8 +32,7 @@ export type StartingPoint = Project | RemoteRepoRef;
  * Register a project creation operation
  */
 export interface GeneratorRegistration<PARAMS = NoParameters>
-    extends Partial<GeneratorCommandDetails<any>>,
-        ProjectOperationRegistration<PARAMS> {
+    extends ProjectOperationRegistration<PARAMS> {
 
     /**
      * Starting point before transformation. Normally the coordinates of a
@@ -41,6 +40,11 @@ export interface GeneratorRegistration<PARAMS = NoParameters>
      * The alternative is to get this from a config object.
      */
     startingPoint?: StartingPoint;
+
+    /**
+     * Strategy for persisting projects. Useful in testing.
+     */
+    projectPersister?: ProjectPersister;
 
     /**
      * Allow customization of the target for this repo,


### PR DESCRIPTION
- No longer extends `automation-client` command hierarchy, offering more control in `sdm`
- `editMode` now `TransformMode` and provides access to both SdmContext and project
