### PR TITLE
Add ability to select projects using a ProjectPredicate for inspections and transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "fmt:gql": "prettier --write \"**/*.graphql\"",
     "clean:barrels": "rimraf src/index.ts",
     "generate:barrels": "npm-run-all clean:barrels generate:cleaned-barrels",
-    "generate:cleaned-barrels": "barrelsby -d src --i 'api/.*' --i 'spi/.*' --i typings/.* --e CommandRegistration.*",
+    "generate:cleaned-barrels": "barrelsby -d src --i 'api/.*' --i 'spi/.*' --i typings/.* --e CommandRegistration.* -e ProjectsOperationRegistration.* -e ProjectOperationRegistration.*",
     "git:info": "atomist git",
     "gql:copy": "copyfiles \"./src/**/*.graphql\" build",
     "gql:gen": "atomist gql-gen --no-install \"src/graphql/**/*.graphql\"",

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -125,7 +125,7 @@ export function codeInspectionRegistrationToCommand<R>(sdm: MachineOrMachineOpti
                 return ci.addressChannels(`:no_entry: Invalid parameters to code inspection: ${vr.message}`);
             }
             const action: (p: Project, params: any) => Promise<InspectionResult<R>> = async p => {
-                if (!!cir.projectTest && !cir.projectTest(p)) {
+                if (!!cir.projectTest && !(await cir.projectTest(p))) {
                     return { repoId: p.id, result: undefined };
                 }
                 return { repoId: p.id, result: await cir.inspection(p, ci) };
@@ -332,8 +332,8 @@ export function toScalarProjectEditor<PARAMS>(ctot: CodeTransformOrTransforms<PA
         toProjectEditor(ctot);
     if (!!projectPredicate) {
         // Filter out this project if it doesn't match the predicate
-        return (p, context, params) => {
-            return projectPredicate(p) ?
+        return async (p, context, params) => {
+            return (await projectPredicate(p)) ?
                 unguarded(p, context, params) :
                 Promise.resolve({ success: true, edited: false, target: p });
         };

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -25,14 +25,20 @@ import { ProjectsOperationRegistration } from "./ProjectsOperationRegistration";
  * compute a value.
  */
 export type CodeInspection<R, P = NoParameters> = (p: Project,
-                                                   sdmc: CommandListenerInvocation<P>) => Promise<R>;
+                                                   cli: CommandListenerInvocation<P>) => Promise<R>;
 
 /**
  * Result of inspecting a single project
  */
 export interface InspectionResult<R> {
+
     repoId: RepoRef;
-    result: R;
+
+    /**
+     * Inspection result can be undefined if a repo was returned by an all repo query but the
+     * inspection was not run on that repo because it did not match the project predicate specified in the registration.
+     */
+    result: R | undefined;
 }
 
 /**

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
 import { RepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
-import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { CommandListenerInvocation } from "../listener/CommandListener";
-import { RepoTargets } from "../machine/RepoTargets";
-import { CommandRegistration } from "./CommandRegistration";
+import { ProjectsOperationRegistration } from "./ProjectsOperationRegistration";
 
 /**
  * Function that can run against a project without mutating it to
@@ -43,19 +40,9 @@ export interface InspectionResult<R> {
  * Include an optional react method that can react to review results.
  */
 export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
-    extends CommandRegistration<PARAMS> {
+    extends ProjectsOperationRegistration<PARAMS> {
 
     inspection: CodeInspection<R, PARAMS>;
-
-    /**
-     * Allow customization of the repositories that an inspection targets.
-     */
-    targets?: Maker<RepoTargets>;
-
-    /**
-     * Additionally, programmatically target repositories to inspect
-     */
-    repoFilter?: RepoFilter;
 
     /**
      * React to computed values from running across one or more projects

--- a/src/api/registration/CodeTransformRegistration.ts
+++ b/src/api/registration/CodeTransformRegistration.ts
@@ -14,27 +14,20 @@
  * limitations under the License.
  */
 
-import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
 import { EditMode } from "@atomist/automation-client/operations/edit/editModes";
 import { EditResult } from "@atomist/automation-client/operations/edit/projectEditor";
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
-import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { CommandListenerInvocation } from "../listener/CommandListener";
-import { RepoTargets } from "../machine/RepoTargets";
 import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
+import { ProjectsOperationRegistration } from "./ProjectsOperationRegistration";
 
 /**
  * Type for registering a project transform, which can make changes
  * across projects
  */
 export interface CodeTransformRegistration<PARAMS = NoParameters>
-    extends ProjectOperationRegistration<PARAMS> {
-
-    /**
-     * Allow customization of the repositories a transform targets.
-     */
-    targets?: Maker<RepoTargets>;
+    extends ProjectOperationRegistration<PARAMS>, ProjectsOperationRegistration<PARAMS> {
 
     /**
      * How to present the transformation
@@ -42,11 +35,6 @@ export interface CodeTransformRegistration<PARAMS = NoParameters>
      * @return {EditMode}
      */
     transformPresentation?: (ci: CommandListenerInvocation<PARAMS>, p: Project) => EditMode;
-
-    /**
-     * Additionally, programmatically target repositories to transform
-     */
-    repoFilter?: RepoFilter;
 
     /**
      * React to results from running edits across one or more projects

--- a/src/api/registration/ProjectsOperationRegistration.ts
+++ b/src/api/registration/ProjectsOperationRegistration.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { CommandRegistration } from "./CommandRegistration";
 import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
-import { RepoTargets } from "../machine/RepoTargets";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
+import { RepoTargets } from "../machine/RepoTargets";
+import { ProjectPredicate } from "../mapping/PushTest";
+import { CommandRegistration } from "./CommandRegistration";
 
 /**
  * Superclass for all registrations that can apply to one or more projects.
@@ -30,8 +31,14 @@ export interface ProjectsOperationRegistration<PARAMS> extends CommandRegistrati
     targets?: Maker<RepoTargets>;
 
     /**
-     * Additionally, programmatically target repositories to inspect
+     * Additionally, programmatically limit repositories to inspect, by id
      */
     repoFilter?: RepoFilter;
+
+    /**
+     * Programmatically limit repositories to inspect, by a project predicate.
+     * This can look inside project.
+     */
+    projectTest?: ProjectPredicate;
 
 }

--- a/src/api/registration/ProjectsOperationRegistration.ts
+++ b/src/api/registration/ProjectsOperationRegistration.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommandRegistration } from "./CommandRegistration";
+import { RepoFilter } from "@atomist/automation-client/operations/common/repoFilter";
+import { RepoTargets } from "../machine/RepoTargets";
+import { Maker } from "@atomist/automation-client/util/constructionUtils";
+
+/**
+ * Superclass for all registrations that can apply to one or more projects.
+ */
+export interface ProjectsOperationRegistration<PARAMS> extends CommandRegistration<PARAMS> {
+
+    /**
+     * Allow customization of the repositories that an inspection targets.
+     */
+    targets?: Maker<RepoTargets>;
+
+    /**
+     * Additionally, programmatically target repositories to inspect
+     */
+    repoFilter?: RepoFilter;
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,6 @@ export * from "./api/registration/IngesterRegistration";
 export * from "./api/registration/IngesterRegistrationManager";
 export * from "./api/registration/ParametersBuilder";
 export * from "./api/registration/ParametersDefinition";
-export * from "./api/registration/ProjectOperationRegistration";
 export * from "./api/registration/PushImpactListenerRegistration";
 export * from "./api/registration/PushRegistration";
 export * from "./api/registration/ReviewerError";


### PR DESCRIPTION
- Introduce new superinterface (not exposed in index) for consistency
- Add an optional `projectTest` project predicate for code transforms and inspections. This allows the use of our internal DSL for project selection.