### PR TITLE
Added ability to seal goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Collect names of Goal and Goals instances in contributor model. [#461](https://github.com/atomist/sdm/issues/461)
 -   Add `GoalExecutionListener` to track goal execution within an SDM.
 -   Add support voting on goal approval in an SDM. [#465](https://github.com/atomist/sdm/issues/465)
+-   Added ability to seal goal sets with "contribution" model, via `Goals.andSeal()`
 
 ### Changed
 

--- a/src/api/goal/Goals.ts
+++ b/src/api/goal/Goals.ts
@@ -28,6 +28,27 @@ export class Goals {
 
     public readonly goals: Goal[];
 
+    private sealedFlag: boolean;
+
+    /**
+     * Are these goals sealed? That is, should we prevent any more goals being set
+     * if a push includes these goals.
+     * This applies in the contributor model of `goalContributors`.
+     */
+    get sealed(): boolean {
+        return this.sealedFlag;
+    }
+
+    /**
+     * Return a sealed form of these goals
+     * @return {this}
+     */
+    public andSeal(): Goals {
+        const sealedGoals = new Goals(this.name, ...this.goals);
+        sealedGoals.sealedFlag = true;
+        return sealedGoals;
+    }
+
     // tslint:disable-next-line:no-shadowed-variable
     constructor(public name: string, ...goals: Goal[]) {
         this.goals = goals;


### PR DESCRIPTION
Backward compatible.

Invoke `onSeal()` on `Goals` to ensure that contribution model ceases to add goals to any matching push.