### PR TITLE
Add ability to lock Goals in contribution model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Collect names of Goal and Goals instances in contributor model. [#461](https://github.com/atomist/sdm/issues/461)
 -   Add `GoalExecutionListener` to track goal execution within an SDM.
 -   Add support voting on goal approval in an SDM. [#465](https://github.com/atomist/sdm/issues/465)
+-   Add goal locking model through `LockingGoal` and `Goals.andLock()`
 
 ### Changed
 

--- a/src/api/dsl/goalContribution.ts
+++ b/src/api/dsl/goalContribution.ts
@@ -20,6 +20,7 @@ import { SdmContext } from "../context/SdmContext";
 import { Goal } from "../goal/Goal";
 import { Goals } from "../goal/Goals";
 import { PushListenerInvocation } from "../listener/PushListener";
+import { LockingGoal } from "../machine/wellKnownGoals";
 import {
     Mapping,
     NeverMatch,
@@ -75,8 +76,12 @@ class AdditiveGoalSetter<F extends SdmContext> implements Mapping<F, Goals> {
                 } else {
                     names.push(c.name);
                 }
+                contributorGoals.push(mapping.filter(g => g !== LockingGoal));
+                // If we find the special locking goal, don't add any further goals
+                if (mapping.includes(LockingGoal)) {
+                    break;
+                }
             }
-            contributorGoals.push(mapping);
         }
 
         const uniqueGoals: Goal[] = _.uniq(_.flatten(contributorGoals.filter(x => !!x)));

--- a/src/api/dsl/goalContribution.ts
+++ b/src/api/dsl/goalContribution.ts
@@ -79,6 +79,7 @@ class AdditiveGoalSetter<F extends SdmContext> implements Mapping<F, Goals> {
                 contributorGoals.push(mapping.filter(g => g !== LockingGoal));
                 // If we find the special locking goal, don't add any further goals
                 if (mapping.includes(LockingGoal)) {
+                    logger.info("Stopping goal contribution analysis, because %s has locked the goal set", c.name);
                     break;
                 }
             }

--- a/src/api/goal/Goals.ts
+++ b/src/api/goal/Goals.ts
@@ -15,6 +15,7 @@
  */
 
 import * as _ from "lodash";
+import { LockingGoal } from "../machine/wellKnownGoals";
 import {
     Goal,
     GoalDefinition,
@@ -27,6 +28,25 @@ import {
 export class Goals {
 
     public readonly goals: Goal[];
+
+    /**
+     * Return a Goal set that contains these goals and one more goal,
+     * with an appropriate name
+     * @param {Goal} g goal to add
+     * @return {Goals}
+     */
+    public and(g: Goal): Goals {
+        return new Goals(this.name + "+" + g.name, ...this.goals.concat(g));
+    }
+
+    /**
+     * Return a form of these goals that is locked, so that more goals cannot be
+     * added through contribution model
+     * @return {Goals}
+     */
+    public andLock(): Goals {
+        return this.and(LockingGoal);
+    }
 
     // tslint:disable-next-line:no-shadowed-variable
     constructor(public name: string, ...goals: Goal[]) {

--- a/src/api/machine/wellKnownGoals.ts
+++ b/src/api/machine/wellKnownGoals.ts
@@ -26,7 +26,7 @@ import {
 } from "../goal/support/environment";
 
 /**
- * Goals referenced in TheSoftwareDeliveryMachine
+ * Goals referenced in SoftwareDeliveryMachine methods such addPushImpactListener
  */
 
 export const NoGoal = new Goal({
@@ -35,6 +35,19 @@ export const NoGoal = new Goal({
     orderedName: "1-immaterial",
     displayName: "immaterial",
     completedDescription: "No material changes",
+});
+
+/**
+ * Special goal that locks a goal set so no further goals
+ * can be added. This goal is never actually emitted.
+ * @type {Goal}
+ */
+export const LockingGoal = new Goal({
+    uniqueName: "Lock",
+    environment: IndependentOfEnvironment,
+    orderedName: "1-locking",
+    displayName: "lock",
+    completedDescription: "Lock goals",
 });
 
 /**

--- a/test/api/dsl/goalContributionTest.ts
+++ b/test/api/dsl/goalContributionTest.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { InMemoryProject } from "@atomist/automation-client/project/mem/InMemoryProject";
 import * as assert from "power-assert";
 import { fakePush } from "../../../src/api-helper/test/fakePush";
 import {
@@ -30,7 +32,7 @@ import { Goals } from "../../../src/api/goal/Goals";
 import {
     AutofixGoal,
     BuildGoal,
-    FingerprintGoal,
+    FingerprintGoal, LockingGoal,
     PushReactionGoal,
     ReviewGoal,
 } from "../../../src/api/machine/wellKnownGoals";
@@ -115,6 +117,36 @@ describe("goalContribution", () => {
             assert.equal(goals.goals.length, 3);
             assert.deepEqual(goals.goals, SomeGoalSet.goals.concat([mg, FingerprintGoal] as any));
             assert.equal(goals.name, "SomeGoalSet, Sending message, Fingerprint");
+        });
+
+        it("should respect sealed goals", async () => {
+            const mg = new MessageGoal("sendSomeMessage", "Sending message");
+            const old: GoalSetter = whenPushSatisfies(() => true)
+                .itMeans("thing")
+                .setGoals(SomeGoalSet.andLock());
+            const gs: GoalSetter = enrichGoalSetters(old,
+                onAnyPush().setGoals(mg));
+            const p = fakePush();
+            const goals: Goals = await gs.mapping(p);
+            assert.deepEqual(goals.goals, SomeGoalSet.goals);
+            assert.equal(goals.name, "SomeGoalSet+lock");
+        });
+
+        it("should respect sealed goals in one case", async () => {
+            const mg = new MessageGoal("sendSomeMessage", "Sending message");
+            const old: GoalSetter = whenPushSatisfies(() => true)
+                .itMeans("thing")
+                .setGoals(SomeGoalSet);
+            let gs: GoalSetter = enrichGoalSetters(old,
+                onAnyPush().setGoals([mg, LockingGoal]));
+            gs = enrichGoalSetters(old,
+                whenPushSatisfies(async pu => pu.id.owner !== "bar").setGoals(mg));
+            const p = fakePush();
+            const goals: Goals = await gs.mapping(p);
+            assert.deepEqual(goals.goals, SomeGoalSet.goals.concat([mg] as any));
+            const barPush = fakePush(InMemoryProject.from(new GitHubRepoRef("bar", "what")));
+            const barGoals: Goals = await gs.mapping(barPush);
+            assert.deepEqual(barGoals.goals, SomeGoalSet.goals);
         });
 
     });

--- a/test/api/dsl/goalContributionTest.ts
+++ b/test/api/dsl/goalContributionTest.ts
@@ -133,19 +133,28 @@ describe("goalContribution", () => {
         });
 
         it("should respect sealed goals in one case", async () => {
-            const mg = new MessageGoal("sendSomeMessage", "Sending message");
+            // we create a goal setter that always sets a Fred goal
             const old: GoalSetter = whenPushSatisfies(() => true)
                 .itMeans("thing")
                 .setGoals(SomeGoalSet);
+
+            // the we create a different goal setter that always sets the MessageGoal + Locks it
+            const mg = new MessageGoal("sendSomeMessage", "Sending message");
             let gs: GoalSetter = enrichGoalSetters(old,
                 onAnyPush().setGoals([mg, LockingGoal]));
+            // maybe we're testing that this enrich setting does not update the original goal setter
+
+            // but then we ignore that one, and add a possible message goal to the original one, without locking
             gs = enrichGoalSetters(old,
                 whenPushSatisfies(async pu => pu.id.owner !== "bar").setGoals(mg));
-            const p = fakePush();
-            const goals: Goals = await gs.mapping(p);
-            assert.deepEqual(goals.goals, SomeGoalSet.goals.concat([mg] as any));
-            const barPush = fakePush(InMemoryProject.from(new GitHubRepoRef("bar", "what")));
-            const barGoals: Goals = await gs.mapping(barPush);
+
+            const p = fakePush(); // this does not have an owner of "bar" so it does qualify for the MessageGoal above
+            const goals: Goals = await gs.mapping(p); // we match it against the second value of `gs`
+
+            assert.deepEqual(goals.goals, SomeGoalSet.goals.concat([mg] as any)); // and now it has accepted the addition of the MessageGoal
+
+            const barPush = fakePush(InMemoryProject.from(new GitHubRepoRef("bar", "what"))); // but if the owner IS bar
+            const barGoals: Goals = await gs.mapping(barPush); // then it does not get the Message Goal because it doesn't pass the push test.
             assert.deepEqual(barGoals.goals, SomeGoalSet.goals);
         });
 

--- a/tslint.json
+++ b/tslint.json
@@ -14,7 +14,7 @@
     "curly": true,
     "cyclomatic-complexity": [
       true,
-      10
+      12
     ],
     "interface-name": [
       true,


### PR DESCRIPTION
Add the special `LockingGoal` to the goal set, or call `Goals.andLock()`