### PR TITLE
Get enough data to  find the repo

### DIFF
--- a/src/graphql/query/ReposInTeam.graphql
+++ b/src/graphql/query/ReposInTeam.graphql
@@ -3,6 +3,13 @@ query ReposInTeam($offset: Int!, $size: Int!) {
     orgs {
       repo(first: $size, offset: $offset) {
         name
+        owner
+        org {
+          provider {
+            providerType
+            apiUrl
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
because all graphql fields are optional, all the types match up fine,
and DefaultRepoRefResolver in sdm-core expects these fields, but they're
not in the query here.
This prevents targets.repos selection from working at all on transforms