### PR TITLE
Specific logging on cleanup of cached project

### DIFF
--- a/src/api-helper/project/CachingProjectLoader.ts
+++ b/src/api-helper/project/CachingProjectLoader.ts
@@ -86,8 +86,8 @@ export class CachingProjectLoader implements ProjectLoader {
  * @param action
  */
 async function saveAndRunAction<T>(delegate: ProjectLoader,
-    params: ProjectLoadingParameters,
-    action: WithLoadedProject): Promise<T> {
+                                   params: ProjectLoadingParameters,
+                                   action: WithLoadedProject): Promise<T> {
     const p = await save(delegate, params);
     if (params.context && params.context.lifecycle) {
         params.context.lifecycle.registerDisposable(async () => cleanUp(p, "disposal"));

--- a/src/api-helper/project/CachingProjectLoader.ts
+++ b/src/api-helper/project/CachingProjectLoader.ts
@@ -105,7 +105,7 @@ async function saveAndRunAction<T>(delegate: ProjectLoader,
 function cleanUp(p: GitProject, reason: "timeout" | "disposal" | "eviction"): void {
     if (p && p.baseDir && fs.existsSync(p.baseDir)) {
         if (reason === "timeout") {
-            logger.info(`Deleting project  '%j' at '%s' because a timeout passed`, p.id, p.baseDir);
+            logger.info(`Deleting project '%j' at '%s' because a timeout passed`, p.id, p.baseDir);
         } else {
             logger.debug(`Deleting project '%j' at '%s' because %s was triggered`, p.id, p.baseDir, reason);
         }


### PR DESCRIPTION
hey @cdupuis that cleanup-after-10-seconds raised some warning flags in my head, because some operations can take that long, and it would be really hard to figure out why the operation crashed in that case. How about we log that at a higher level than if we have reason to believe we're done?