### PR TITLE
Add project invariant concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/atomist/sdm/compare/1.0.0-M.1...HEAD)
 
+### Added
+
+-   Added `EnforceableProjectInvariantRegistration`
+
+### Changed
+
+-   **BREAKING* `AutofixRegistration.parameters` method renamed to `parametersInstance`
+-   **BREAKING** `CodeTransformRegistration.react` method renamed to `onTransformResults`
+-   **BREAKING** `CodeInspectionRegistration.react` method renamed to `onInspectionResults`
+
 ## [1.0.0-M.1](https://github.com/atomist/sdm/compare/0.4.8...1.0.0-M.1) - 2018-08-27
 
 ## [0.4.8](https://github.com/atomist/sdm/compare/0.4.7...0.4.8) - 2018-08-27
@@ -64,7 +74,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Add `GoalExecutionListener` to track goal execution within an SDM.
 -   Add support voting on goal approval in an SDM. [#465](https://github.com/atomist/sdm/issues/465)
 -   Add goal locking model through `LockingGoal` and `Goals.andLock()`
--   Added `EnforceableProjectInvariantRegistration`
 
 ### Changed
 
@@ -75,8 +84,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   **BREAKING**  `CodeTransformRegistration.editMode` is replaced by `transformPresentation`.
 -   **BREAKING** `CommandHandler` registrations must now specify a `listener`. `createCommand` alternative is removed.
 -   **BREAKING** Review listeners must now have names. Introduced `ReviewListenerRegistration`
--   **BREAKING** `CodeTransformRegistration.react` method renamed to `onTransformResults`
--   **BREAKING** `CodeInspectionRegistration.react` method renamed to `onInspectionResults`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Add `GoalExecutionListener` to track goal execution within an SDM.
 -   Add support voting on goal approval in an SDM. [#465](https://github.com/atomist/sdm/issues/465)
 -   Add goal locking model through `LockingGoal` and `Goals.andLock()`
+-   Added `EnforceableProjectInvariantRegistration`
 
 ### Changed
 
@@ -74,6 +75,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   **BREAKING**  `CodeTransformRegistration.editMode` is replaced by `transformPresentation`.
 -   **BREAKING** `CommandHandler` registrations must now specify a `listener`. `createCommand` alternative is removed.
 -   **BREAKING** Review listeners must now have names. Introduced `ReviewListenerRegistration`
+-   **BREAKING** `CodeTransformRegistration.react` method renamed to `onTransformResults`
+-   **BREAKING** `CodeInspectionRegistration.react` method renamed to `onInspectionResults`
 
 ### Fixed
 

--- a/src/api-helper/listener/executeAutofixes.ts
+++ b/src/api-helper/listener/executeAutofixes.ts
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-import {
-    logger,
-    Success,
-} from "@atomist/automation-client";
+import { logger, Success } from "@atomist/automation-client";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { EditResult } from "@atomist/automation-client/operations/edit/projectEditor";
 import { combineEditResults } from "@atomist/automation-client/operations/edit/projectEditorOps";
 import * as _ from "lodash";
 import { sprintf } from "sprintf-js";
 import { ExecuteGoalResult } from "../../api/goal/ExecuteGoalResult";
-import {
-    ExecuteGoal,
-    GoalInvocation,
-} from "../../api/goal/GoalInvocation";
+import { ExecuteGoal, GoalInvocation } from "../../api/goal/GoalInvocation";
 import { PushImpactListenerInvocation } from "../../api/listener/PushImpactListener";
 import { AutofixRegistration } from "../../api/registration/AutofixRegistration";
 import { ProgressLog } from "../../spi/log/ProgressLog";
@@ -105,7 +99,10 @@ async function runOne(cri: PushImpactListenerInvocation,
     const project = cri.project;
     progressLog.write(sprintf("About to edit %s with autofix %s", (project.id as RemoteRepoRef).url, autofix.name));
     try {
-        const tentativeEditResult = await toScalarProjectEditor(autofix.transform)(project, cri.context, autofix.parameters);
+        const tentativeEditResult = await toScalarProjectEditor(autofix.transform)(
+            project,
+            cri.context,
+            autofix.parametersInstance);
         const editResult = await confirmEditedness(tentativeEditResult);
 
         if (!editResult.success) {

--- a/src/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
+++ b/src/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
@@ -365,7 +365,7 @@ function transformToInspection<PARAMS>(transform: CodeTransformOrTransforms<PARA
         const result = await editor(p, i.context, i.parameters);
         return {
             id: p.id as RemoteRepoRef,
-            holds: result.edited,
+            holds: !result.edited,
             details: "Transform return edited true",
         };
     };

--- a/src/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
+++ b/src/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
@@ -166,6 +166,7 @@ export abstract class AbstractSoftwareDeliveryMachine<O extends SoftwareDelivery
     public addEnforceableInvariant<PARAMS>(eir: EnforceableProjectInvariantRegistration<PARAMS>): this {
         const ctr: CodeTransformRegistration = {
             ...eir,
+            // Update the name and set an intent
             name: `transform-${eir.name}`,
             intent: !!eir.intent ? toStringArray(eir.intent).map(i => `transform ${i}`) : `transform ${eir.name}`,
         } as CodeTransformRegistration;
@@ -341,7 +342,7 @@ function toCodeInspectionCommand<PARAMS>(
         intent: !!eir.intent ? toStringArray(eir.intent).map(i => `verify ${i}`) : `verify ${eir.name}`,
         parameters: eir.parameters,
         projectTest: eir.projectTest,
-        reactToResults: eir.reactToResults,
+        onInspectionResults: eir.onInspectionResults,
         description: eir.description,
         tags: eir.tags,
         targets: eir.targets,

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -197,8 +197,8 @@ export function codeInspectionRegistrationToCommand<R>(sdm: MachineOrMachineOpti
                 repoFinder,
                 andFilter(targets.test, cir.repoFilter),
                 repoLoader);
-            if (!!cir.react) {
-                await cir.react(results, ci);
+            if (!!cir.reactToResults) {
+                await cir.reactToResults(results, ci);
             } else {
                 logger.info("No react function to react to results of code inspection '%s'", cir.name);
             }

--- a/src/api-helper/machine/handlerRegistrations.ts
+++ b/src/api-helper/machine/handlerRegistrations.ts
@@ -143,8 +143,8 @@ export function codeTransformRegistrationToCommand(sdm: MachineOrMachineOptions,
                 repoFinder,
                 andFilter(targets.test, ctr.repoFilter),
                 repoLoader);
-            if (!!ctr.react) {
-                await ctr.react(results, ci);
+            if (!!ctr.onTransformResults) {
+                await ctr.onTransformResults(results, ci);
             } else {
                 logger.info("No react function to react to results of code transformation '%s'", ctr.name);
             }
@@ -197,8 +197,8 @@ export function codeInspectionRegistrationToCommand<R>(sdm: MachineOrMachineOpti
                 repoFinder,
                 andFilter(targets.test, cir.repoFilter),
                 repoLoader);
-            if (!!cir.reactToResults) {
-                await cir.reactToResults(results, ci);
+            if (!!cir.onInspectionResults) {
+                await cir.onInspectionResults(results, ci);
             } else {
                 logger.info("No react function to react to results of code inspection '%s'", cir.name);
             }

--- a/src/api/machine/SoftwareDeliveryMachine.ts
+++ b/src/api/machine/SoftwareDeliveryMachine.ts
@@ -21,6 +21,7 @@ import { PushRule } from "../mapping/support/PushRule";
 import { StaticPushMapping } from "../mapping/support/StaticPushMapping";
 import { EventRegistrationManager } from "../registration/EventRegistrationManager";
 import { IngesterRegistrationManager } from "../registration/IngesterRegistrationManager";
+import { EnforceableProjectInvariantRegistration } from "../registration/ProjectInvariantRegistration";
 import { CommandRegistrationManager } from "./CommandRegistrationManager";
 import { ExtensionPack } from "./ExtensionPack";
 import { FunctionalUnit } from "./FunctionalUnit";
@@ -77,6 +78,16 @@ export interface SoftwareDeliveryMachine<O extends SoftwareDeliveryMachineConfig
     addDisposalRules(...goalSetters: GoalSetter[]): this;
 
     addVerifyImplementation(): this;
+
+    /**
+     * Add an enforceable invariant registration. This will export
+     * a CodeTransform, CodeInspection and Autofix.
+     * If a ProjectInvariant is not enforceable, it can be
+     * registered with addCodeInspection.
+     * @param {EnforceableProjectInvariantRegistration<PARAMS>} eir
+     * @return {this}
+     */
+    addEnforceableInvariant<PARAMS>(eir: EnforceableProjectInvariantRegistration<PARAMS>): this;
 
     /**
      * Add capabilities from these extension packs.

--- a/src/api/machine/SoftwareDeliveryMachine.ts
+++ b/src/api/machine/SoftwareDeliveryMachine.ts
@@ -84,6 +84,8 @@ export interface SoftwareDeliveryMachine<O extends SoftwareDeliveryMachineConfig
      * a CodeTransform, CodeInspection and Autofix.
      * If a ProjectInvariant is not enforceable, it can be
      * registered with addCodeInspection.
+     * The transform command is exposed via "transform <intent>"
+     * The inspection command is exposed via "verify <intent>"
      * @param {EnforceableProjectInvariantRegistration<PARAMS>} eir
      * @return {this}
      */

--- a/src/api/project/exports.ts
+++ b/src/api/project/exports.ts
@@ -49,3 +49,5 @@ import * as validationPatterns from "@atomist/automation-client/operations/commo
 export { validationPatterns };
 
 export { SeedDrivenGeneratorParameters } from "@atomist/automation-client/operations/generate/SeedDrivenGeneratorParameters";
+
+export { EditResult } from "@atomist/automation-client/operations/edit/projectEditor";

--- a/src/api/registration/AutofixRegistration.ts
+++ b/src/api/registration/AutofixRegistration.ts
@@ -37,5 +37,5 @@ export interface AutofixRegistration<P = NoParameters> extends PushSelector {
     /**
      * Parameters used for all transforms
      */
-    parameters?: P;
+    parametersInstance?: P;
 }

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -42,11 +42,9 @@ export interface InspectionResult<R> {
 }
 
 /**
- * Register a CodeInspection that can run against any number of projects.
- * Include an optional react method that can react to review results.
+ * Actions added by inspections. For internal use.
  */
-export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
-    extends ProjectsOperationRegistration<PARAMS> {
+export interface InspectionActions<R, PARAMS> {
 
     inspection: CodeInspection<R, PARAMS>;
 
@@ -57,5 +55,14 @@ export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
      * @return {Promise<any>}
      */
     reactToResults?(results: Array<InspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+}
+
+/**
+ * Register a CodeInspection that can run against any number of projects.
+ * Include an optional react method that can react to review results.
+ */
+export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
+    extends ProjectsOperationRegistration<PARAMS>,
+        InspectionActions<R, PARAMS> {
 
 }

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -56,6 +56,6 @@ export interface CodeInspectionRegistration<R, PARAMS = NoParameters>
      * @param ci context
      * @return {Promise<any>}
      */
-    react?(results: Array<InspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+    reactToResults?(results: Array<InspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
 
 }

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -46,6 +46,9 @@ export interface InspectionResult<R> {
  */
 export interface InspectionActions<R, PARAMS> {
 
+    /**
+     * Inspection function to run on each project
+     */
     inspection: CodeInspection<R, PARAMS>;
 
     /**
@@ -54,7 +57,7 @@ export interface InspectionActions<R, PARAMS> {
      * @param ci context
      * @return {Promise<any>}
      */
-    reactToResults?(results: Array<InspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+    onInspectionResults?(results: Array<InspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
 }
 
 /**

--- a/src/api/registration/CodeTransformRegistration.ts
+++ b/src/api/registration/CodeTransformRegistration.ts
@@ -42,7 +42,7 @@ export interface CodeTransformRegistration<PARAMS = NoParameters>
      * @param ci context
      * @return {Promise<any>}
      */
-    react?(results: EditResult[], ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+    onTransformResults?(results: EditResult[], ci: CommandListenerInvocation<PARAMS>): Promise<any>;
 
 }
 

--- a/src/api/registration/ProjectInvariantRegistration.ts
+++ b/src/api/registration/ProjectInvariantRegistration.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { ProjectReview, RemoteRepoRef } from "../project/exports";
 import { AutofixRegistration } from "./AutofixRegistration";

--- a/src/api/registration/ProjectInvariantRegistration.ts
+++ b/src/api/registration/ProjectInvariantRegistration.ts
@@ -1,0 +1,32 @@
+import { NoParameters } from "@atomist/automation-client/SmartParameters";
+import { ProjectReview, RemoteRepoRef } from "../project/exports";
+import { AutofixRegistration } from "./AutofixRegistration";
+import { CodeInspectionRegistration } from "./CodeInspectionRegistration";
+import { CodeTransformRegistration } from "./CodeTransformRegistration";
+
+/**
+ * Can register as a code inspection
+ */
+export interface ProjectInvariantRegistration<PARAMS = NoParameters>
+    extends CodeInspectionRegistration<InvarianceAssessment, PARAMS> {
+
+}
+
+/**
+ * An invariant that can be enforced.
+ * 3-in-1: Inspection, CodeTransform and Autofix. Emits all
+ */
+export interface EnforceableProjectInvariantRegistration<PARAMS = NoParameters>
+    extends ProjectInvariantRegistration<PARAMS>,
+        CodeTransformRegistration<PARAMS>,
+        AutofixRegistration<PARAMS> {
+
+}
+
+export interface InvarianceAssessment {
+    id: RemoteRepoRef;
+
+    holds: boolean;
+
+    review?: ProjectReview;
+}

--- a/src/api/registration/ProjectInvariantRegistration.ts
+++ b/src/api/registration/ProjectInvariantRegistration.ts
@@ -17,7 +17,7 @@
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { ProjectReview, RemoteRepoRef } from "../project/exports";
 import { AutofixRegistration } from "./AutofixRegistration";
-import { CodeInspectionRegistration } from "./CodeInspectionRegistration";
+import { CodeInspectionRegistration, InspectionActions } from "./CodeInspectionRegistration";
 import { CodeTransformRegistration } from "./CodeTransformRegistration";
 
 /**
@@ -29,20 +29,29 @@ export interface ProjectInvariantRegistration<PARAMS = NoParameters>
 }
 
 /**
- * An invariant that can be enforced.
- * 3-in-1: Inspection, CodeTransform and Autofix. Emits all
+ * An invariant that can be enforced via an autofix.
+ * Based around a CodeTransform which can be used as a command or an autofix.
+ * If the CodeInspection isn't specified,
+ * a CodeInspection will be created based on running the transform and seeing if
+ * it makes changes.
  */
 export interface EnforceableProjectInvariantRegistration<PARAMS = NoParameters>
-    extends ProjectInvariantRegistration<PARAMS>,
+    extends Partial<InspectionActions<InvarianceAssessment, PARAMS>>,
         CodeTransformRegistration<PARAMS>,
         AutofixRegistration<PARAMS> {
 
 }
 
+/**
+ * Result of assessing an invariant against a repo
+ */
 export interface InvarianceAssessment {
+
     id: RemoteRepoRef;
 
     holds: boolean;
 
     review?: ProjectReview;
+
+    details?: string;
 }

--- a/src/api/registration/ProjectInvariantRegistration.ts
+++ b/src/api/registration/ProjectInvariantRegistration.ts
@@ -49,6 +49,9 @@ export interface InvarianceAssessment {
 
     id: RemoteRepoRef;
 
+    /**
+     * Does the invariant hold for this project?
+     */
     holds: boolean;
 
     review?: ProjectReview;

--- a/src/api/registration/PushRegistration.ts
+++ b/src/api/registration/PushRegistration.ts
@@ -16,6 +16,9 @@
 
 import { PushTest } from "../mapping/PushTest";
 
+/**
+ * Extended by any object that can react to a subset of pushes.
+ */
 export interface PushSelector {
 
     name: string;

--- a/test/api-helper/TestSoftwareDeliveryMachine.ts
+++ b/test/api-helper/TestSoftwareDeliveryMachine.ts
@@ -19,6 +19,9 @@ import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { AbstractSoftwareDeliveryMachine } from "../../src/api-helper/machine/AbstractSoftwareDeliveryMachine";
 import { GoalSetter } from "../../src/api/mapping/GoalSetter";
 
+/**
+ * SDM instance for use in tests
+ */
 export class TestSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMachine {
 
     public readonly commandHandlers: Array<Maker<HandleCommand>>;

--- a/test/api-helper/listener/executeAutofixesTest.ts
+++ b/test/api-helper/listener/executeAutofixesTest.ts
@@ -66,7 +66,7 @@ export const AddThingWithParamAutofix: AutofixRegistration<BirdParams> = {
         assert(!ci.parameters);
         return { edited: true, success: true, target: project };
     },
-    parameters: {
+    parametersInstance: {
         bird: "ibis",
     },
 };

--- a/tslint.json
+++ b/tslint.json
@@ -61,7 +61,6 @@
     "no-switch-case-fall-through": true,
     "no-unnecessary-class": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-var-keyword": true,
     "object-literal-shorthand": true,
     "prefer-readonly": true,


### PR DESCRIPTION
Introduces new registration that can function as a transform, inspection and autofix, naturally expressing the notion of a project invariant.

Built on lower level concepts.

Required renaming of the `react` methods on `CodeTransformRegistration` and `CodeInspectionRegistration` and `parameters` on `AutofixRegistration` to avoid conflict. This renaming is an improvement, as it's clearer.