### PR TITLE
Add AutoInspect registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 -   Added `EnforceableProjectInvariantRegistration`.
--   Added `AutoInspectRegistration`
+-   Added `AutoInspectRegistration`.
 
 ### Changed
 
 -   **BREAKING** `AutofixRegistration.parameters` method renamed to `parametersInstance`.
 -   **BREAKING** `CodeTransformRegistration.react` method renamed to `onTransformResults`.
 -   **BREAKING** `CodeInspectionRegistration.react` method renamed to `onInspectionResults`.
--   **BREAKING** `ReviewerRegistration.action` renamed `inspect`
+-   **BREAKING** `ReviewerRegistration.action` renamed `inspect`.
 
 ## [1.0.0-M.1](https://github.com/atomist/sdm/compare/0.4.8...1.0.0-M.1) - 2018-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 -   Added `EnforceableProjectInvariantRegistration`.
+-   Added `AutoInspectRegistration`
 
 ### Changed
 
 -   **BREAKING** `AutofixRegistration.parameters` method renamed to `parametersInstance`.
 -   **BREAKING** `CodeTransformRegistration.react` method renamed to `onTransformResults`.
 -   **BREAKING** `CodeInspectionRegistration.react` method renamed to `onInspectionResults`.
+-   **BREAKING** `ReviewerRegistration.action` renamed `inspect`
 
 ## [1.0.0-M.1](https://github.com/atomist/sdm/compare/0.4.8...1.0.0-M.1) - 2018-08-27
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "fmt:gql": "prettier --write \"**/*.graphql\"",
     "clean:barrels": "rimraf src/index.ts",
     "generate:barrels": "npm-run-all clean:barrels generate:cleaned-barrels",
-    "generate:cleaned-barrels": "barrelsby -d src --i 'api/.*' --i 'spi/.*' --i typings/.* --e CommandRegistration.* -e ProjectsOperationRegistration.* -e ProjectOperationRegistration.*",
+    "generate:cleaned-barrels": "barrelsby -d src --i 'api/.*' --i 'spi/.*' --i typings/.* -e CommandRegistration.* -e ParametersInvocation.* -e ProjectsOperationRegistration.* -e ProjectOperationRegistration.*",
     "git:info": "atm-git-info",
     "gql:copy": "copyfiles \"./src/**/*.graphql\" build",
     "gql:gen": "atm-gql-gen",

--- a/src/api-helper/code/review/patternMatchReviewer.ts
+++ b/src/api-helper/code/review/patternMatchReviewer.ts
@@ -15,10 +15,7 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import {
-    ProjectReview,
-    Severity,
-} from "@atomist/automation-client/operations/review/ReviewResult";
+import { ProjectReview, Severity, } from "@atomist/automation-client/operations/review/ReviewResult";
 import { doWithFiles } from "@atomist/automation-client/project/util/projectUtils";
 import * as _ from "lodash";
 import { PushTest } from "../../../api/mapping/PushTest";
@@ -63,9 +60,8 @@ export function patternMatchReviewer(name: string,
     return {
         name,
         pushTest: opts.pushTest,
-        action: async cri => {
+        inspection: async (project, cri) => {
             logger.debug("Running regexp review '%s' on %s against %j", name, opts.globPattern, antiPatterns);
-            const project = cri.project;
             const result: ProjectReview = {repoId: project.id, comments: []};
             await doWithFiles(project, opts.globPattern, async f => {
                 const content = await f.getContent();

--- a/src/api-helper/code/review/patternMatchReviewer.ts
+++ b/src/api-helper/code/review/patternMatchReviewer.ts
@@ -15,7 +15,7 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import { ProjectReview, Severity, } from "@atomist/automation-client/operations/review/ReviewResult";
+import { ProjectReview, Severity } from "@atomist/automation-client/operations/review/ReviewResult";
 import { doWithFiles } from "@atomist/automation-client/project/util/projectUtils";
 import * as _ from "lodash";
 import { PushTest } from "../../../api/mapping/PushTest";

--- a/src/api-helper/listener/executeAutoInspects.ts
+++ b/src/api-helper/listener/executeAutoInspects.ts
@@ -44,10 +44,7 @@ export function executeAutoInspects(projectLoader: ProjectLoader,
             if (autoInspectRegistrations.length > 0) {
                 logger.info("Planning inspection of %j with %d AutoInspects", id, autoInspectRegistrations.length);
                 return projectLoader.doWithProject({ credentials, id, readOnly: true }, async project => {
-                    const cri = {
-                        ...await createPushImpactListenerInvocation(goalInvocation, project),
-                        commandName: "autoInspection",
-                    };
+                    const cri = await createPushImpactListenerInvocation(goalInvocation, project);
                     const relevantAutoInspects = await relevantCodeActions(autoInspectRegistrations, cri);
                     logger.info("Executing review of %j with %d relevant AutoInspects: [%s] of [%s]",
                         id, relevantAutoInspects.length,

--- a/src/api-helper/machine/ListenerRegistrationManagerSupport.ts
+++ b/src/api-helper/machine/ListenerRegistrationManagerSupport.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { ArtifactListenerRegisterable } from "../../api/listener/ArtifactListener";
 import { BuildListener } from "../../api/listener/BuildListener";
 import { ChannelLinkListener } from "../../api/listener/ChannelLinkListenerInvocation";
@@ -36,12 +37,11 @@ import { UserJoiningChannelListener } from "../../api/listener/UserJoiningChanne
 import { VerifiedDeploymentListener } from "../../api/listener/VerifiedDeploymentListener";
 import { ListenerRegistrationManager } from "../../api/machine/ListenerRegistrationManager";
 import { AutofixRegistration } from "../../api/registration/AutofixRegistration";
+import { AutoInspectRegistration } from "../../api/registration/AutoInspectRegistration";
 import { FingerprinterRegistration } from "../../api/registration/FingerprinterRegistration";
 import { PushImpactListenerRegisterable } from "../../api/registration/PushImpactListenerRegistration";
 import { ReviewerRegistration } from "../../api/registration/ReviewerRegistration";
 import { ReviewListenerRegistration } from "../../api/registration/ReviewListenerRegistration";
-import { AutoInspectRegistration } from "../../api/registration/AutoInspectRegistration";
-import { NoParameters } from "@atomist/automation-client/SmartParameters";
 
 /**
  * Listener management offering a fluent builder pattern for registrations.
@@ -83,7 +83,7 @@ export class ListenerRegistrationManagerSupport implements ListenerRegistrationM
 
     public readonly goalExecutionListeners: GoalExecutionListener[] = [];
 
-    public readonly autoInspectRegistrations: AutoInspectRegistration<any, any>[] = [];
+    public readonly autoInspectRegistrations: Array<AutoInspectRegistration<any, any>> = [];
 
     public readonly reviewListenerRegistrations: ReviewListenerRegistration[] = [];
 
@@ -172,7 +172,6 @@ export class ListenerRegistrationManagerSupport implements ListenerRegistrationM
     public addAutoInspectRegistration<R, PARAMS = NoParameters>(r: AutoInspectRegistration<R, PARAMS>): this {
         return this;
     }
-
 
     public addReviewListenerRegistration(r: ReviewListenerRegistration): this {
         this.reviewListenerRegistrations.push(r);

--- a/src/api-helper/machine/ListenerRegistrationManagerSupport.ts
+++ b/src/api-helper/machine/ListenerRegistrationManagerSupport.ts
@@ -40,6 +40,8 @@ import { FingerprinterRegistration } from "../../api/registration/FingerprinterR
 import { PushImpactListenerRegisterable } from "../../api/registration/PushImpactListenerRegistration";
 import { ReviewerRegistration } from "../../api/registration/ReviewerRegistration";
 import { ReviewListenerRegistration } from "../../api/registration/ReviewListenerRegistration";
+import { AutoInspectRegistration } from "../../api/registration/AutoInspectRegistration";
+import { NoParameters } from "@atomist/automation-client/SmartParameters";
 
 /**
  * Listener management offering a fluent builder pattern for registrations.
@@ -81,7 +83,7 @@ export class ListenerRegistrationManagerSupport implements ListenerRegistrationM
 
     public readonly goalExecutionListeners: GoalExecutionListener[] = [];
 
-    public readonly reviewerRegistrations: ReviewerRegistration[] = [];
+    public readonly autoInspectRegistrations: AutoInspectRegistration<any, any>[] = [];
 
     public readonly reviewListenerRegistrations: ReviewListenerRegistration[] = [];
 
@@ -162,10 +164,15 @@ export class ListenerRegistrationManagerSupport implements ListenerRegistrationM
         return this;
     }
 
-    public addReviewerRegistration(r: ReviewerRegistration): this {
-        this.reviewerRegistrations.push(r);
+    public addReviewerRegistration<PARAMS = NoParameters>(r: ReviewerRegistration<PARAMS>): this {
+        this.autoInspectRegistrations.push(r);
         return this;
     }
+
+    public addAutoInspectRegistration<R, PARAMS = NoParameters>(r: AutoInspectRegistration<R, PARAMS>): this {
+        return this;
+    }
+
 
     public addReviewListenerRegistration(r: ReviewListenerRegistration): this {
         this.reviewListenerRegistrations.push(r);

--- a/src/api-helper/machine/ListenerRegistrationManagerSupport.ts
+++ b/src/api-helper/machine/ListenerRegistrationManagerSupport.ts
@@ -170,6 +170,7 @@ export class ListenerRegistrationManagerSupport implements ListenerRegistrationM
     }
 
     public addAutoInspectRegistration<R, PARAMS = NoParameters>(r: AutoInspectRegistration<R, PARAMS>): this {
+        this.autoInspectRegistrations.push(r);
         return this;
     }
 

--- a/src/api/listener/ParametersInvocation.ts
+++ b/src/api/listener/ParametersInvocation.ts
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
-import { NoParameters } from "@atomist/automation-client/SmartParameters";
-import { SdmListener } from "./Listener";
-import { ParametersInvocation } from "./ParametersInvocation";
+import { SdmContext } from "../context/SdmContext";
 
 /**
- * Context for a commmand
+ * Context for anything with parameters. All commands
+ * have parameters, as do autofixes and auto inspections.
  */
-export interface CommandListenerInvocation<PARAMS = NoParameters> extends ParametersInvocation<PARAMS> {
-
-    commandName: string;
+export interface ParametersInvocation<PARAMS> extends SdmContext {
 
     /**
-     * The repos this command relates to, if available.
+     * Parameters, if any were supplied
      */
-    ids?: RemoteRepoRef[];
+    parameters?: PARAMS;
 
 }
-
-export type CommandListener<PARAMS = NoParameters> =
-    SdmListener<CommandListenerInvocation<PARAMS>>;

--- a/src/api/machine/ListenerRegistrationManager.ts
+++ b/src/api/machine/ListenerRegistrationManager.ts
@@ -23,9 +23,7 @@ import { EndpointVerificationListener } from "../listener/EndpointVerificationLi
 import { FingerprintDifferenceListener } from "../listener/FingerprintDifferenceListener";
 import { FingerprintListener } from "../listener/FingerprintListener";
 import { GoalCompletionListener } from "../listener/GoalCompletionListener";
-import {
-    GoalsSetListener,
-} from "../listener/GoalsSetListener";
+import { GoalsSetListener, } from "../listener/GoalsSetListener";
 import { GoalExecutionListener } from "../listener/GoalStatusListener";
 import { NewIssueListener } from "../listener/NewIssueListener";
 import { ProjectListener } from "../listener/ProjectListener";
@@ -36,13 +34,13 @@ import { TagListener } from "../listener/TagListener";
 import { UpdatedIssueListener } from "../listener/UpdatedIssueListener";
 import { UserJoiningChannelListener } from "../listener/UserJoiningChannelListener";
 import { VerifiedDeploymentListener } from "../listener/VerifiedDeploymentListener";
-import {
-    AutofixRegistration,
-} from "../registration/AutofixRegistration";
+import { AutofixRegistration, } from "../registration/AutofixRegistration";
 import { FingerprinterRegistration } from "../registration/FingerprinterRegistration";
 import { PushImpactListenerRegisterable } from "../registration/PushImpactListenerRegistration";
 import { ReviewerRegistration } from "../registration/ReviewerRegistration";
 import { ReviewListenerRegistration } from "../registration/ReviewListenerRegistration";
+import { AutoInspectRegistration } from "../registration/AutoInspectRegistration";
+import { NoParameters } from "@atomist/automation-client/SmartParameters";
 
 /**
  * Listener management offering a fluent builder pattern for registrations.
@@ -111,6 +109,18 @@ export interface ListenerRegistrationManager {
 
     addGoalCompletionListener(l: GoalCompletionListener): this;
 
+    /**
+     * Register an auto inspection.
+     * @param {AutoInspectRegistration<R, PARAMS>} r
+     * @return {this}
+     */
+    addAutoInspectRegistration<R, PARAMS=NoParameters>(r: AutoInspectRegistration<R, PARAMS>): this;
+
+    /**
+     * @deprecated use addAutoInspectRegistration
+     * @param {ReviewerRegistration} r
+     * @return {this}
+     */
     addReviewerRegistration(r: ReviewerRegistration): this;
 
     /**
@@ -183,7 +193,7 @@ export interface ListenerRegistrationManager {
 
     goalCompletionListeners: GoalCompletionListener[];
 
-    reviewerRegistrations: ReviewerRegistration[];
+    autoInspectRegistrations: AutoInspectRegistration<any, any>[];
 
     reviewListenerRegistrations: ReviewListenerRegistration[];
 

--- a/src/api/machine/ListenerRegistrationManager.ts
+++ b/src/api/machine/ListenerRegistrationManager.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { ArtifactListenerRegisterable } from "../listener/ArtifactListener";
 import { BuildListener } from "../listener/BuildListener";
 import { ChannelLinkListener } from "../listener/ChannelLinkListenerInvocation";
@@ -23,7 +24,7 @@ import { EndpointVerificationListener } from "../listener/EndpointVerificationLi
 import { FingerprintDifferenceListener } from "../listener/FingerprintDifferenceListener";
 import { FingerprintListener } from "../listener/FingerprintListener";
 import { GoalCompletionListener } from "../listener/GoalCompletionListener";
-import { GoalsSetListener, } from "../listener/GoalsSetListener";
+import { GoalsSetListener } from "../listener/GoalsSetListener";
 import { GoalExecutionListener } from "../listener/GoalStatusListener";
 import { NewIssueListener } from "../listener/NewIssueListener";
 import { ProjectListener } from "../listener/ProjectListener";
@@ -34,13 +35,12 @@ import { TagListener } from "../listener/TagListener";
 import { UpdatedIssueListener } from "../listener/UpdatedIssueListener";
 import { UserJoiningChannelListener } from "../listener/UserJoiningChannelListener";
 import { VerifiedDeploymentListener } from "../listener/VerifiedDeploymentListener";
-import { AutofixRegistration, } from "../registration/AutofixRegistration";
+import { AutofixRegistration } from "../registration/AutofixRegistration";
+import { AutoInspectRegistration } from "../registration/AutoInspectRegistration";
 import { FingerprinterRegistration } from "../registration/FingerprinterRegistration";
 import { PushImpactListenerRegisterable } from "../registration/PushImpactListenerRegistration";
 import { ReviewerRegistration } from "../registration/ReviewerRegistration";
 import { ReviewListenerRegistration } from "../registration/ReviewListenerRegistration";
-import { AutoInspectRegistration } from "../registration/AutoInspectRegistration";
-import { NoParameters } from "@atomist/automation-client/SmartParameters";
 
 /**
  * Listener management offering a fluent builder pattern for registrations.
@@ -114,7 +114,7 @@ export interface ListenerRegistrationManager {
      * @param {AutoInspectRegistration<R, PARAMS>} r
      * @return {this}
      */
-    addAutoInspectRegistration<R, PARAMS=NoParameters>(r: AutoInspectRegistration<R, PARAMS>): this;
+    addAutoInspectRegistration<R, PARAMS= NoParameters>(r: AutoInspectRegistration<R, PARAMS>): this;
 
     /**
      * @deprecated use addAutoInspectRegistration
@@ -193,7 +193,7 @@ export interface ListenerRegistrationManager {
 
     goalCompletionListeners: GoalCompletionListener[];
 
-    autoInspectRegistrations: AutoInspectRegistration<any, any>[];
+    autoInspectRegistrations: Array<AutoInspectRegistration<any, any>>;
 
     reviewListenerRegistrations: ReviewListenerRegistration[];
 

--- a/src/api/registration/AutoInspectRegistration.ts
+++ b/src/api/registration/AutoInspectRegistration.ts
@@ -15,10 +15,12 @@
  */
 
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
-import { CommandListenerInvocation } from "../listener/CommandListener";
 import { ParametersInvocation } from "../listener/ParametersInvocation";
 import { CodeInspection } from "./CodeInspectionRegistration";
-import { PushReactionResponse, SelectiveCodeActionOptions } from "./PushImpactListenerRegistration";
+import {
+    PushReactionResponse,
+    SelectiveCodeActionOptions,
+} from "./PushImpactListenerRegistration";
 import { PushSelector } from "./PushRegistration";
 
 export type AutoInspectRegistrationOptions = SelectiveCodeActionOptions;

--- a/src/api/registration/AutoInspectRegistration.ts
+++ b/src/api/registration/AutoInspectRegistration.ts
@@ -18,15 +18,16 @@ import { SelectiveCodeActionOptions, } from "./PushImpactListenerRegistration";
 import { CodeInspection } from "./CodeInspectionRegistration";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { PushSelector } from "./PushRegistration";
+import { CommandListenerInvocation } from "../listener/CommandListener";
 
-export type AutoInspectionRegistrationOptions = SelectiveCodeActionOptions;
+export type AutoInspectRegistrationOptions = SelectiveCodeActionOptions;
 
 /**
  * Register an automatic inspection.
  */
-export interface AutoInspectionRegistration<R, PARAMS = NoParameters> extends PushSelector {
+export interface AutoInspectRegistration<R, PARAMS = NoParameters> extends PushSelector {
 
-    options?: AutoInspectionRegistrationOptions;
+    options?: AutoInspectRegistrationOptions;
 
     /**
      * Inspection function to run on each project
@@ -37,4 +38,12 @@ export interface AutoInspectionRegistration<R, PARAMS = NoParameters> extends Pu
      * Parameters used for all inspections
      */
     parametersInstance?: PARAMS;
+
+    /**
+     * Invoked after each inspection result, if provided
+     * @param {R} result
+     * @param {CommandListenerInvocation<PARAMS>} ci
+     * @return {Promise<any>}
+     */
+    onInspectionResult?(result: R, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
 }

--- a/src/api/registration/AutoInspectRegistration.ts
+++ b/src/api/registration/AutoInspectRegistration.ts
@@ -19,6 +19,7 @@ import { CodeInspection } from "./CodeInspectionRegistration";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { PushSelector } from "./PushRegistration";
 import { CommandListenerInvocation } from "../listener/CommandListener";
+import { ParametersInvocation } from "../listener/ParametersInvocation";
 
 export type AutoInspectRegistrationOptions = SelectiveCodeActionOptions;
 
@@ -45,5 +46,5 @@ export interface AutoInspectRegistration<R, PARAMS = NoParameters> extends PushS
      * @param {CommandListenerInvocation<PARAMS>} ci
      * @return {Promise<any>}
      */
-    onInspectionResult?(result: R, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+    onInspectionResult?(result: R, ci: ParametersInvocation<PARAMS>): Promise<any>;
 }

--- a/src/api/registration/AutoInspectRegistration.ts
+++ b/src/api/registration/AutoInspectRegistration.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { SelectiveCodeActionOptions, } from "./PushImpactListenerRegistration";
-import { CodeInspection } from "./CodeInspectionRegistration";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
-import { PushSelector } from "./PushRegistration";
 import { CommandListenerInvocation } from "../listener/CommandListener";
 import { ParametersInvocation } from "../listener/ParametersInvocation";
+import { CodeInspection } from "./CodeInspectionRegistration";
+import { PushReactionResponse, SelectiveCodeActionOptions } from "./PushImpactListenerRegistration";
+import { PushSelector } from "./PushRegistration";
 
 export type AutoInspectRegistrationOptions = SelectiveCodeActionOptions;
 
@@ -41,10 +41,12 @@ export interface AutoInspectRegistration<R, PARAMS = NoParameters> extends PushS
     parametersInstance?: PARAMS;
 
     /**
-     * Invoked after each inspection result, if provided
+     * Invoked after each inspection result, if provided.
+     * A void return means keep processing this push. Return a
+     * PushReactionResponse to demand approval or fail goals.
      * @param {R} result
-     * @param {CommandListenerInvocation<PARAMS>} ci
+     * @param {ParametersInvocation<PARAMS>} ci
      * @return {Promise<any>}
      */
-    onInspectionResult?(result: R, ci: ParametersInvocation<PARAMS>): Promise<any>;
+    onInspectionResult?(result: R, ci: ParametersInvocation<PARAMS>): Promise<PushReactionResponse | void>;
 }

--- a/src/api/registration/AutoInspectionRegistration.ts
+++ b/src/api/registration/AutoInspectionRegistration.ts
@@ -14,14 +14,27 @@
  * limitations under the License.
  */
 
-import { ProjectReview } from "@atomist/automation-client/operations/review/ReviewResult";
-import { AutoInspectionRegistration } from "./AutoInspectionRegistration";
+import { SelectiveCodeActionOptions, } from "./PushImpactListenerRegistration";
+import { CodeInspection } from "./CodeInspectionRegistration";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
+import { PushSelector } from "./PushRegistration";
+
+export type AutoInspectionRegistrationOptions = SelectiveCodeActionOptions;
 
 /**
- * Register a reviewer. This can return structured data based on a project.
+ * Register an automatic inspection.
  */
-export interface ReviewerRegistration<PARAMS = NoParameters>
-    extends AutoInspectionRegistration<ProjectReview, PARAMS> {
+export interface AutoInspectionRegistration<R, PARAMS = NoParameters> extends PushSelector {
 
+    options?: AutoInspectionRegistrationOptions;
+
+    /**
+     * Inspection function to run on each project
+     */
+    inspection: CodeInspection<R, PARAMS>;
+
+    /**
+     * Parameters used for all inspections
+     */
+    parametersInstance?: PARAMS;
 }

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -18,8 +18,8 @@ import { RepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { CommandListenerInvocation } from "../listener/CommandListener";
-import { ProjectsOperationRegistration } from "./ProjectsOperationRegistration";
 import { ParametersInvocation } from "../listener/ParametersInvocation";
+import { ProjectsOperationRegistration } from "./ProjectsOperationRegistration";
 
 /**
  * Function that can run against a project without mutating it to

--- a/src/api/registration/CodeInspectionRegistration.ts
+++ b/src/api/registration/CodeInspectionRegistration.ts
@@ -19,13 +19,14 @@ import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { CommandListenerInvocation } from "../listener/CommandListener";
 import { ProjectsOperationRegistration } from "./ProjectsOperationRegistration";
+import { ParametersInvocation } from "../listener/ParametersInvocation";
 
 /**
  * Function that can run against a project without mutating it to
  * compute a value.
  */
 export type CodeInspection<R, P = NoParameters> = (p: Project,
-                                                   cli: CommandListenerInvocation<P>) => Promise<R>;
+                                                   cli: ParametersInvocation<P>) => Promise<R>;
 
 /**
  * Result of inspecting a single project

--- a/src/api/registration/CodeTransform.ts
+++ b/src/api/registration/CodeTransform.ts
@@ -20,7 +20,7 @@ import { EditResult } from "@atomist/automation-client/operations/edit/projectEd
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { GraphClient } from "@atomist/automation-client/spi/graph/GraphClient";
-import { MessageClient, SlackMessageClient, } from "@atomist/automation-client/spi/message/MessageClient";
+import { MessageClient, SlackMessageClient } from "@atomist/automation-client/spi/message/MessageClient";
 import { ParametersInvocation } from "../listener/ParametersInvocation";
 
 /**
@@ -74,7 +74,7 @@ export interface HandlerContextMethods {
 /**
  * Function that can transform a project. Mixing HandlerContextMethods into second
  * parameter, and third parameter are only for backward compatibility.
- * New code should use (Project, Command ListenerInvocation).
+ * New code should use (Project, Command ParametersInvocation).
  */
 export type CodeTransform<P = NoParameters> = (p: Project,
                                                sdmc: ParametersInvocation<P> & HandlerContextMethods,

--- a/src/api/registration/CodeTransform.ts
+++ b/src/api/registration/CodeTransform.ts
@@ -20,11 +20,8 @@ import { EditResult } from "@atomist/automation-client/operations/edit/projectEd
 import { Project } from "@atomist/automation-client/project/Project";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 import { GraphClient } from "@atomist/automation-client/spi/graph/GraphClient";
-import {
-    MessageClient,
-    SlackMessageClient,
-} from "@atomist/automation-client/spi/message/MessageClient";
-import { CommandListenerInvocation } from "../listener/CommandListener";
+import { MessageClient, SlackMessageClient, } from "@atomist/automation-client/spi/message/MessageClient";
+import { ParametersInvocation } from "../listener/ParametersInvocation";
 
 /**
  * This interface contains methods from HandlerContext.
@@ -80,7 +77,7 @@ export interface HandlerContextMethods {
  * New code should use (Project, Command ListenerInvocation).
  */
 export type CodeTransform<P = NoParameters> = (p: Project,
-                                               sdmc: CommandListenerInvocation<P> & HandlerContextMethods,
+                                               sdmc: ParametersInvocation<P> & HandlerContextMethods,
                                                params?: P) => Promise<Project | EditResult>;
 
 /**

--- a/src/api/registration/PushImpactListenerRegistration.ts
+++ b/src/api/registration/PushImpactListenerRegistration.ts
@@ -25,6 +25,11 @@ import { PushRegistration } from "./PushRegistration";
 export enum PushReactionResponse {
 
     /**
+     * Everything's good. Keep going.
+     */
+    proceed = "proceed",
+
+    /**
      * Fail execution of the present goalset. Any dependent goals will stop.
      * Will not stop execution of non-dependent goals.
      */

--- a/src/api/registration/ReviewerRegistration.ts
+++ b/src/api/registration/ReviewerRegistration.ts
@@ -15,8 +15,8 @@
  */
 
 import { ProjectReview } from "@atomist/automation-client/operations/review/ReviewResult";
-import { AutoInspectRegistration } from "./AutoInspectRegistration";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
+import { AutoInspectRegistration } from "./AutoInspectRegistration";
 
 /**
  * Register a reviewer. This can return structured data based on a project.

--- a/src/api/registration/ReviewerRegistration.ts
+++ b/src/api/registration/ReviewerRegistration.ts
@@ -15,13 +15,13 @@
  */
 
 import { ProjectReview } from "@atomist/automation-client/operations/review/ReviewResult";
-import { AutoInspectionRegistration } from "./AutoInspectionRegistration";
+import { AutoInspectRegistration } from "./AutoInspectRegistration";
 import { NoParameters } from "@atomist/automation-client/SmartParameters";
 
 /**
  * Register a reviewer. This can return structured data based on a project.
  */
 export interface ReviewerRegistration<PARAMS = NoParameters>
-    extends AutoInspectionRegistration<ProjectReview, PARAMS> {
+    extends AutoInspectRegistration<ProjectReview, PARAMS> {
 
 }

--- a/test/api-helper/code/review/patternMatchReviewerTest.ts
+++ b/test/api-helper/code/review/patternMatchReviewerTest.ts
@@ -19,7 +19,6 @@ import { InMemoryFile } from "@atomist/automation-client/project/mem/InMemoryFil
 import { InMemoryProject } from "@atomist/automation-client/project/mem/InMemoryProject";
 import * as assert from "power-assert";
 import { patternMatchReviewer } from "../../../../src/api-helper/code/review/patternMatchReviewer";
-import { PushImpactListenerInvocation } from "../../../../src/api/listener/PushImpactListener";
 import { ReviewerRegistration } from "../../../../src/api/registration/ReviewerRegistration";
 
 describe("patternMatchReviewer", () => {
@@ -33,7 +32,7 @@ describe("patternMatchReviewer", () => {
                 comment: "something else",
             });
         const project = InMemoryProject.of(new InMemoryFile("a", "b"));
-        const rr = await rer.action({project} as any as PushImpactListenerInvocation);
+        const rr = await rer.inspection(project, null);
         assert.equal(rr.comments.length, 0);
     });
 
@@ -46,7 +45,7 @@ describe("patternMatchReviewer", () => {
                 comment: "something else",
             });
         const project = InMemoryProject.of(new InMemoryFile("thing", "b test"));
-        const rr = await rer.action({project} as any as PushImpactListenerInvocation);
+        const rr = await rer.inspection(project, null);
         assert.equal(rr.comments.length, 1);
         assert.equal(rr.comments[0].sourceLocation.path, "thing");
     });
@@ -60,7 +59,7 @@ describe("patternMatchReviewer", () => {
                 comment: "something else",
             });
         const project = InMemoryProject.of(new InMemoryFile("thing", "b test"));
-        const rr = await rer.action({project} as any as PushImpactListenerInvocation);
+        const rr = await rer.inspection(project, null);
         assert.equal(rr.comments.length, 0);
     });
 
@@ -73,7 +72,7 @@ describe("patternMatchReviewer", () => {
                 comment: "something else",
             });
         const project = InMemoryProject.of(new InMemoryFile("thing", "b frogs suck test"));
-        const rr = await rer.action({project} as any as PushImpactListenerInvocation);
+        const rr = await rer.inspection(project, null);
         assert.equal(rr.comments.length, 1);
         assert.equal(rr.comments[0].sourceLocation.path, "thing");
     });
@@ -87,7 +86,7 @@ describe("patternMatchReviewer", () => {
                 comment: "something else",
             });
         const project = InMemoryProject.of(new InMemoryFile("thing", "b frogs /[&(* suck test"));
-        const rr = await rer.action({project} as any as PushImpactListenerInvocation);
+        const rr = await rer.inspection(project, null);
         assert.equal(rr.comments.length, 1);
         assert.equal(rr.comments[0].sourceLocation.path, "thing");
     });

--- a/test/api-helper/listener/executeAutoInspectTest.ts
+++ b/test/api-helper/listener/executeAutoInspectTest.ts
@@ -25,7 +25,7 @@ import { TruePushTest } from "../../api/mapping/support/pushTestUtilsTest";
 
 import { InMemoryFile } from "@atomist/automation-client/project/mem/InMemoryFile";
 import * as assert from "power-assert";
-import { executeReview } from "../../../src/api-helper/listener/executeReview";
+import { executeAutoInspects } from "../../../src/api-helper/listener/executeAutoInspects";
 import { fakeGoalInvocation } from "../../../src/api-helper/test/fakeGoalInvocation";
 import { SingleProjectLoader } from "../../../src/api-helper/test/SingleProjectLoader";
 import { PushReactionResponse } from "../../../src/api/registration/PushImpactListenerRegistration";
@@ -79,14 +79,14 @@ function loggingReviewListenerWithoutApproval(saveTo: ReviewListenerInvocation[]
     };
 }
 
-describe("executeReview", () => {
+describe("executeAutoInspects", () => {
 
     it("should be clean on empty", async () => {
         const id = new GitHubRepoRef("a", "b");
         const p = InMemoryProject.from(id);
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithApproval(reviewEvents);
-        const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld], [{
+        const ge = executeAutoInspects(new SingleProjectLoader(p), [HatesTheWorld], [{
             name: "thing",
             listener: l,
         }]);
@@ -102,7 +102,7 @@ describe("executeReview", () => {
         const p = InMemoryProject.from(id, new InMemoryFile("thing", "1"));
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithApproval(reviewEvents);
-        const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld], [{
+        const ge = executeAutoInspects(new SingleProjectLoader(p), [HatesTheWorld], [{
             name: "thing",
             listener: l,
         }]);
@@ -120,7 +120,7 @@ describe("executeReview", () => {
         const p = InMemoryProject.from(id, new InMemoryFile("thing", "1"));
         const reviewEvents: ReviewListenerInvocation[] = [];
         const listener = loggingReviewListenerWithoutApproval(reviewEvents);
-        const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld], [{
+        const ge = executeAutoInspects(new SingleProjectLoader(p), [HatesTheWorld], [{
             name: "thing",
             listener,
         }]);
@@ -138,7 +138,7 @@ describe("executeReview", () => {
         const p = InMemoryProject.from(id, new InMemoryFile("thing", "1"));
         const reviewEvents: ReviewListenerInvocation[] = [];
         const listener = loggingReviewListenerWithApproval(reviewEvents);
-        const ge = executeReview(new SingleProjectLoader(p), [HatesTheWorld, JustTheOne],
+        const ge = executeAutoInspects(new SingleProjectLoader(p), [HatesTheWorld, JustTheOne],
             [{
                 name: "thing",
                 listener,

--- a/test/api-helper/listener/executeReviewTest.ts
+++ b/test/api-helper/listener/executeReviewTest.ts
@@ -33,9 +33,9 @@ import { PushReactionResponse } from "../../../src/api/registration/PushImpactLi
 const HatesTheWorld: ReviewerRegistration = {
     name: "hatred",
     pushTest: TruePushTest,
-    action: async cri => ({
-        repoId: cri.project.id,
-        comments: await saveFromFiles(cri.project, "**/*", f =>
+    inspection: async project => ({
+        repoId: project.id,
+        comments: await saveFromFiles(project, "**/*", f =>
             new DefaultReviewComment("info", "hater",
                 `Found a file at \`${f.path}\`: We hate all files`,
                 {
@@ -50,8 +50,8 @@ const HatesTheWorld: ReviewerRegistration = {
 const JustTheOne: ReviewerRegistration = {
     name: "justOne",
     pushTest: TruePushTest,
-    action: async cri => ({
-        repoId: cri.project.id,
+    inspection: async project => ({
+        repoId: project.id,
         comments: [
             new DefaultReviewComment("info", "justOne",
                 `One thing`,


### PR DESCRIPTION
- Adds an `AutoInspectRegistration`. `ReviewRegistration` is now a specialization of this.
- Parameters are now available to auto inspections and reviews
- Autofixes and auto inspect/reviewers no longer take misleading `CommandListenerInvocation` but new `ParametersInvocation`
- Added `onInspectionResult` method for auto inspect/reviewers