### PR TITLE
Pass depth down to `git clone` in order to correctly diff the changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@atomist/automation-client": {
-      "version": "1.0.0-M.3",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.0.0-M.3.tgz",
-      "integrity": "sha512-yZGQVbBRp0OCMm2FTBr2pHWusLPjEmd31i3g0uONwWA6RMcBCl5iEzHDlgLy8QNa3Fj/kXRRcSalySIpgVbvrQ==",
+      "version": "1.0.0-master.20180905201706",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.0.0-master.20180905201706.tgz",
+      "integrity": "sha512-8RAuMSFljTjaDWsgWsudkCF0YAe/JjUgIFYPRTt3nTi7fyshwSt3X74kebARGlV4vlrC28SXBlq0iB+NdYTJtw==",
       "dev": true,
       "requires": {
         "@atomist/microgrammar": "^0.8.1",
@@ -22,7 +22,7 @@
         "@types/cors": "^2.8.3",
         "@types/cross-spawn": "^6.0.0",
         "@types/express": "^4.11.1",
-        "@types/fs-extra": "^5.0.0",
+        "@types/fs-extra": "^5.0.4",
         "@types/glob": "^5.0.35",
         "@types/graphql": "^0.13.4",
         "@types/helmet": "0.0.38",
@@ -31,7 +31,7 @@
         "@types/json-stringify-safe": "^5.0.0",
         "@types/lodash": "^4.14.104",
         "@types/minimatch": "^3.0.3",
-        "@types/node": "^10.7.1",
+        "@types/node": "^10.9.4",
         "@types/passport": "^0.4.3",
         "@types/passport-http": "^0.3.5",
         "@types/passport-http-bearer": "^1.0.30",
@@ -119,6 +119,12 @@
             "deprecated-decorator": "^0.1.6",
             "lodash": "^4.17.4"
           }
+        },
+        "@types/node": {
+          "version": "10.9.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
+          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
+          "dev": true
         },
         "axios": {
           "version": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix.tgz",
@@ -2385,7 +2391,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -7062,9 +7068,9 @@
       }
     },
     "rxjs": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.1.tgz",
-      "integrity": "sha512-hRVfb1Mcf8rLXq1AZEjYpzBnQbO7Duveu1APXkWRTvqzhmkoQ40Pl2F9Btacx+gJCOqsMiugCGG4I2HPQgJRtA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@atomist/automation-client": "*"
   },
   "devDependencies": {
-    "@atomist/automation-client": "1.0.0-M.3",
+    "@atomist/automation-client": "1.0.0-master.20180905201706",
     "@types/mocha": "^5.2.5",
     "@types/power-assert": "^1.4.29",
     "axios-mock-adapter": "^1.15.0",

--- a/src/api-helper/goal/DefaultGoalImplementationMapper.ts
+++ b/src/api-helper/goal/DefaultGoalImplementationMapper.ts
@@ -40,7 +40,7 @@ export class DefaultGoalImplementationMapper implements GoalImplementationMapper
             m.goal.context === goal.externalKey);
 
         if (matchedNames.length > 1) {
-            throw new Error(`Multiple implementations found for name '${goal.fulfillment.name}' on goal '${goal.name}'`);
+            throw new Error(`Multiple implementations found for name '${goal.fulfillment.name}' on goal '${goal.uniqueName}'`);
         }
         if (matchedNames.length === 0) {
             throw new Error(`No implementation found with name '${goal.fulfillment.name}': ` +

--- a/src/api-helper/listener/createPushImpactListenerInvocation.ts
+++ b/src/api-helper/listener/createPushImpactListenerInvocation.ts
@@ -23,10 +23,7 @@ import { Destination } from "@atomist/automation-client/spi/message/MessageClien
 import { messageDestinationsFor } from "../../api/context/addressChannels";
 import { GoalInvocation } from "../../api/goal/GoalInvocation";
 import { PushImpactListenerInvocation } from "../../api/listener/PushImpactListener";
-import {
-    filesChangedSince,
-    filesChangedSinceParentCommit,
-} from "../misc/git/filesChangedSince";
+import { filesChangedSince } from "../misc/git/filesChangedSince";
 import { filteredView } from "../misc/project/filteredView";
 
 /**
@@ -42,9 +39,7 @@ export async function createPushImpactListenerInvocation(goalInvocation: GoalInv
     const smartContext = teachToRespondInEventHandler(context, ...messageDestinationsFor(sdmGoal.push.repo, context));
 
     const push = sdmGoal.push;
-    const filesChanged = push.before ?
-        await filesChangedSince(project, push.before.sha) :
-        await filesChangedSinceParentCommit(project);
+    const filesChanged = await filesChangedSince(project, push);
     const impactedSubProject = !filesChanged ? project : filteredView(project, path => filesChanged.includes(path));
     return {
         id,

--- a/src/api-helper/listener/executeAutoInspects.ts
+++ b/src/api-helper/listener/executeAutoInspects.ts
@@ -46,11 +46,16 @@ import { relevantCodeActions } from "./relevantCodeActions";
 export function executeAutoInspects(autoInspectRegistrations: Array<AutoInspectRegistration<any, any>>,
                                     reviewListeners: ReviewListenerRegistration[]): ExecuteGoal {
     return async (goalInvocation: GoalInvocation) => {
-        const { configuration, credentials, id, addressChannels } = goalInvocation;
+        const { sdmGoal, configuration, credentials, id, addressChannels } = goalInvocation;
         try {
             if (autoInspectRegistrations.length > 0) {
                 logger.info("Planning inspection of %j with %d AutoInspects", id, autoInspectRegistrations.length);
-                return configuration.sdm.projectLoader.doWithProject({ credentials, id, readOnly: true }, async project => {
+                return configuration.sdm.projectLoader.doWithProject({
+                    credentials,
+                    id,
+                    readOnly: true,
+                    depth: sdmGoal.push.commits.length + 1,
+                }, async project => {
                     const cri = await createPushImpactListenerInvocation(goalInvocation, project);
                     const relevantAutoInspects = await relevantCodeActions(autoInspectRegistrations, cri);
                     logger.info("Executing review of %j with %d relevant AutoInspects: [%s] of [%s]",

--- a/src/api-helper/listener/executeAutofixes.ts
+++ b/src/api-helper/listener/executeAutofixes.ts
@@ -70,6 +70,7 @@ export function executeAutofixes(registrations: AutofixRegistration[]): ExecuteG
                     id: editableRepoRef,
                     context,
                     readOnly: false,
+                    depth: push.commits.length + 1,
                 },
                 async project => {
                     const cri: PushImpactListenerInvocation = await createPushImpactListenerInvocation(goalInvocation, project);

--- a/src/api-helper/listener/executeFingerprinting.ts
+++ b/src/api-helper/listener/executeFingerprinting.ts
@@ -37,13 +37,18 @@ import { relevantCodeActions } from "./relevantCodeActions";
 export function executeFingerprinting(fingerprinters: FingerprinterRegistration[],
                                       listeners: FingerprintListener[]): ExecuteGoal {
     return async (goalInvocation: GoalInvocation) => {
-        const { configuration, id, credentials, context } = goalInvocation;
+        const { sdmGoal, configuration, id, credentials, context } = goalInvocation;
         if (fingerprinters.length === 0) {
             return Success;
         }
 
         logger.debug("About to fingerprint %j using %d fingerprinters", id, fingerprinters.length);
-        await configuration.sdm.projectLoader.doWithProject({ credentials, id, readOnly: true }, async project => {
+        await configuration.sdm.projectLoader.doWithProject({
+            credentials,
+            id,
+            readOnly: true,
+            depth: sdmGoal.push.commits.length + 1,
+        }, async project => {
             const cri = await createPushImpactListenerInvocation(goalInvocation, project);
             const relevantFingerprinters: FingerprinterRegistration[] = await relevantCodeActions(fingerprinters, cri);
             logger.info("Will invoke %d eligible fingerprinters of %d to %j",

--- a/src/api-helper/listener/executePushReactions.ts
+++ b/src/api-helper/listener/executePushReactions.ts
@@ -29,7 +29,6 @@ import {
     PushReactionResponse,
     toPushReactionRegistration,
 } from "../../api/registration/PushImpactListenerRegistration";
-import { ProjectLoader } from "../../spi/project/ProjectLoader";
 import { createPushImpactListenerInvocation } from "./createPushImpactListenerInvocation";
 import { relevantCodeActions } from "./relevantCodeActions";
 
@@ -44,8 +43,14 @@ export function executePushReactions(registrations: PushImpactListenerRegisterab
             return Success;
         }
 
-        const { configuration, credentials, id, context } = goalInvocation;
-        return configuration.sdm.projectLoader.doWithProject({ credentials, id, context, readOnly: true }, async project => {
+        const { sdmGoal, configuration, credentials, id, context } = goalInvocation;
+        return configuration.sdm.projectLoader.doWithProject({
+            credentials,
+            id,
+            context,
+            readOnly: true,
+            depth: sdmGoal.push.commits.length + 1,
+        }, async project => {
             const cri: PushImpactListenerInvocation = await createPushImpactListenerInvocation(goalInvocation, project);
             const regs = registrations.map(toPushReactionRegistration);
             const relevantCodeReactions: PushImpactListenerRegistration[] = await relevantCodeActions<PushImpactListenerRegistration>(regs, cri);

--- a/src/api-helper/project/cloningProjectLoader.ts
+++ b/src/api-helper/project/cloningProjectLoader.ts
@@ -22,7 +22,12 @@ import { ProjectLoader } from "../../spi/project/ProjectLoader";
  */
 export const CloningProjectLoader: ProjectLoader = {
     async doWithProject(coords, action) {
-        const p = await GitCommandGitProject.cloned(coords.credentials, coords.id);
+        // This is breaking old internal code but we need the branch, so this error gives us an opportunity
+        // to fix all lingering cloning issues
+        if (!coords.id.branch) {
+            throw new Error(`Repository reference '${JSON.stringify(coords.id)}' is missing required branch`);
+        }
+        const p = await GitCommandGitProject.cloned(coords.credentials, coords.id, { depth: coords.depth });
         return action(p);
     },
 };

--- a/src/api-helper/test/fakeGoalInvocation.ts
+++ b/src/api-helper/test/fakeGoalInvocation.ts
@@ -15,6 +15,7 @@
  */
 
 import { logger } from "@atomist/automation-client";
+import { guid } from "@atomist/automation-client/internal/util/string";
 import {
     RemoteRepoRef,
     RepoId,
@@ -93,6 +94,7 @@ function fakeSdmGoal(id: RepoId): SdmGoalEvent {
                     },
                 }],
             },
+            commits: [{ sha: guid() }],
         },
     };
 }

--- a/src/api/goal/Goal.ts
+++ b/src/api/goal/Goal.ts
@@ -85,7 +85,7 @@ export class Goal {
     }
 
     get waitingForApprovalDescription() {
-        return this.definition.waitingForApprovalDescription || (this.successDescription + "(but needs approval)");
+        return this.definition.waitingForApprovalDescription || `Approval required: ${this.successDescription}`;
     }
 
     get retryIntent() {

--- a/src/spi/project/ProjectLoader.ts
+++ b/src/spi/project/ProjectLoader.ts
@@ -32,6 +32,9 @@ export interface ProjectLoadingParameters {
 
     /** Return true to get optimized behavior for read only */
     readOnly: boolean;
+
+    /** Indicate how many commits of the history are required */
+    depth?: number;
 }
 
 /**

--- a/test/api-helper/misc/git/filesChangedSince.test.ts
+++ b/test/api-helper/misc/git/filesChangedSince.test.ts
@@ -14,15 +14,82 @@
  * limitations under the License.
  */
 
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { GitCommandGitProject } from "@atomist/automation-client/project/git/GitCommandGitProject";
 import * as assert from "power-assert";
-import { anyFileChangedSuchThat, anyFileChangedWithExtension } from "../../../../src/api-helper/misc/git/filesChangedSince";
+import {
+    anyFileChangedSuchThat,
+    anyFileChangedWithExtension,
+    filesChangedSince,
+} from "../../../../src/api-helper/misc/git/filesChangedSince";
+import { PushFields } from "../../../../src/typings/types";
 
 describe("filesChanged", () => {
 
     describe("changesSince", () => {
 
-        it.skip("parse valid file", () => {
-            // TODO not done yet
+        it("should correctly find all files within two commits", async () => {
+            const p = await GitCommandGitProject.cloned(
+                { token: null },
+                new GitHubRepoRef("atomist-seeds", "spring-rest-seed"),
+                {
+                    depth: 6, // 5 commits in the push + one extra to be able to diff
+                },
+            );
+            const push: PushFields.Fragment = {
+                after: {
+                    sha: "917ad5340a1c03f86633f64032226b277ab366ee",
+                },
+                commits: [{
+                    sha: "917ad5340a1c03f86633f64032226b277ab366ee",
+                }, {
+                    sha: "72cdbbe7c553fc006b5a75ac203e0678575bb314",
+                }, {
+                    sha: "8c55376fb2ceb5f57fbfe111073327cb0adb32c9",
+                }, {
+                    sha: "119820a9de1ab0840a0be2c7fd71ef8f3cd24367",
+                }, {
+                    sha: "50bed8bff0ae8273302d2926e924148d57bad831",
+                }],
+            };
+
+            const files = await filesChangedSince(p, push);
+            const expectedChanges = [".travis.yml",
+                ".travis/controller.patch",
+                ".travis/travis-build.bash",
+                "README.md",
+                "src/main/java/com/atomist/spring/SpringRestSeedController.java"];
+            assert.deepEqual(files, expectedChanges);
+        });
+
+        it("should correctly find all files within two commits on a branch", async () => {
+            const p = await GitCommandGitProject.cloned(
+                { token: null },
+                GitHubRepoRef.from({
+                    owner: "atomist",
+                    repo: "lifecycle-automation",
+                    sha: "1005bdaa2b849f97abd4c45784cf84eba5a34b2e",
+                    branch: "test",
+                }),
+                {
+                    depth: 3, // 2 commits in the push + one extra to be able to diff
+                },
+            );
+            const push: PushFields.Fragment = {
+                after: {
+                    sha: "1005bdaa2b849f97abd4c45784cf84eba5a34b2e",
+                },
+                commits: [{
+                    sha: "1005bdaa2b849f97abd4c45784cf84eba5a34b2e",
+                }, {
+                    sha: "4a725eff5dbfd35f213b97d9c204b402fe45106e",
+                }],
+            };
+
+            const files = await filesChangedSince(p, push);
+            const expectedChanges = [ "README.md",
+                "src/atomist.config.ts"];
+            assert.deepEqual(files, expectedChanges);
         });
 
     });

--- a/test/api-helper/project/lazyProjectLoader.test.ts
+++ b/test/api-helper/project/lazyProjectLoader.test.ts
@@ -42,7 +42,7 @@ describe("LazyProjectLoader", () => {
     });
 
     it("should get file first", async () => {
-        const id = new GitHubRepoRef("spring-team", "spring-rest-seed");
+        const id = GitHubRepoRef.from({ owner: "spring-team", repo: "spring-rest-seed", branch: "master" });
         const lpl = new LazyProjectLoader(CloningProjectLoader);
         const p: Project = await save(lpl, { credentials, id, readOnly: false });
         const f1 = await p.getFile("not-there");
@@ -52,7 +52,7 @@ describe("LazyProjectLoader", () => {
     }).timeout(10000);
 
     it("should get file after stream", async () => {
-        const id = new GitHubRepoRef("spring-team", "spring-rest-seed");
+        const id = GitHubRepoRef.from({ owner: "spring-team", repo: "spring-rest-seed", branch: "master" });
         const lpl = new LazyProjectLoader(CloningProjectLoader);
         const p: Project = await save(lpl, { credentials, id, readOnly: false });
         let count = 0;
@@ -69,7 +69,7 @@ describe("LazyProjectLoader", () => {
     }).timeout(10000);
 
     it("should load for files", async () => {
-        const id = new GitHubRepoRef("spring-team", "spring-rest-seed");
+        const id = GitHubRepoRef.from({ owner: "spring-team", repo: "spring-rest-seed", branch: "master" });
         const lpl = new LazyProjectLoader(CloningProjectLoader);
         const p: Project = await save(lpl, { credentials, id, readOnly: false });
         let count = 0;
@@ -83,7 +83,7 @@ describe("LazyProjectLoader", () => {
 
     it("should materialize once", async () => {
         // Look at log output
-        const id = new GitHubRepoRef("spring-team", "spring-rest-seed");
+        const id = GitHubRepoRef.from({ owner: "spring-team", repo: "spring-rest-seed", branch: "master" });
         const lpl = new LazyProjectLoader(CloningProjectLoader);
         const p: Project = await save(lpl, { credentials, id, readOnly: false });
         const f1 = await p.getFile("not-there");
@@ -95,7 +95,7 @@ describe("LazyProjectLoader", () => {
     }).timeout(10000);
 
     it("should commit and push", async () => {
-        const id = new GitHubRepoRef("this.is.invalid", "nonsense");
+        const id = GitHubRepoRef.from({ owner: "this.is.invalid", repo: "nonsense", branch: "master" });
         const raw = InMemoryProject.from(id, new InMemoryFile("a", "b")) as any as GitProject;
         let commits = 0;
         let pushes = 0;


### PR DESCRIPTION
This now checks the list of commits on the push and passes this + 1 as depth down to the cloning support in order to be able to correctly determine the list of changed files. 

This fixes #481, #328, #293