### PR TITLE
Support code level project listeners

### DIFF
--- a/lib/api-helper/goal/executeBuild.ts
+++ b/lib/api-helper/goal/executeBuild.ts
@@ -29,7 +29,7 @@ import { Builder } from "../../spi/build/Builder";
  */
 export function executeBuild(builder: Builder): ExecuteGoal {
     return async (goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> => {
-        const { sdmGoal, credentials, id, context, progressLog, addressChannels } = goalInvocation;
+        const { sdmGoal, credentials, id, context, progressLog, addressChannels, configuration } = goalInvocation;
 
         logger.info("Building project '%s/%s' with builder '%s'", id.owner, id.repo, builder.name);
 
@@ -48,6 +48,7 @@ export function executeBuild(builder: Builder): ExecuteGoal {
                 sha: sdmGoal.sha,
             },
             progressLog,
-            context);
+            context,
+            configuration);
     };
 }

--- a/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
+++ b/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
@@ -25,7 +25,10 @@ import * as _ from "lodash";
 import { AdminCommunicationContext } from "../../api/context/AdminCommunicationContext";
 import { enrichGoalSetters } from "../../api/dsl/goalContribution";
 import { Goal } from "../../api/goal/Goal";
-import { ExecuteGoal } from "../../api/goal/GoalInvocation";
+import {
+    ExecuteGoal,
+    GoalProjectListener,
+} from "../../api/goal/GoalInvocation";
 import { Goals } from "../../api/goal/Goals";
 import {
     NoProgressReport,
@@ -119,18 +122,17 @@ export abstract class AbstractSoftwareDeliveryMachine<O extends SoftwareDelivery
                                  goal: Goal,
                                  goalExecutor: ExecuteGoal,
                                  options?: Partial<{
-            pushTest: PushTest,
-            logInterpreter: InterpretLog,
-            progressReporter: ReportProgress,
-        }>): this {
+                                     pushTest: PushTest,
+                                     logInterpreter: InterpretLog,
+                                     progressReporter: ReportProgress,
+                                     projectHooks: GoalProjectListener | GoalProjectListener[],
+                                 }>): this {
         const implementation = {
             implementationName, goal, goalExecutor,
-            pushTest: options && options.pushTest ? options.pushTest :
-                AnyPush,
-            logInterpreter: options && options.logInterpreter ? options.logInterpreter :
-                lastLinesLogInterpreter(implementationName, 10),
-            progressReporter: options && options.progressReporter ? options.progressReporter :
-                NoProgressReport,
+            pushTest: _.get(options, "pushTest") || AnyPush,
+            logInterpreter: _.get(options, "logInterpreter") || lastLinesLogInterpreter(implementationName, 10),
+            progressReporter: _.get(options, "progressReporter") || NoProgressReport,
+            projectHooks: _.get(options, "projectHooks") || [],
         };
         this.goalFulfillmentMapper.addImplementation(implementation);
         return this;

--- a/lib/api-helper/project/ProjectListenerInvokingProjectLoader.ts
+++ b/lib/api-helper/project/ProjectListenerInvokingProjectLoader.ts
@@ -61,7 +61,7 @@ export class ProjectListenerInvokingProjectLoader implements ProjectLoader {
             } catch (err) {
                 throw err;
             } finally {
-                // invoke the before_action listeners
+                // invoke the after_action listeners
                 const afterResult = await this.invokeListeners(p, GoalProjectListenerEvent.after_action);
                 if (afterResult && afterResult.code !== 0) {
                     result = afterResult;

--- a/lib/api-helper/project/ProjectListenerInvokingProjectLoader.ts
+++ b/lib/api-helper/project/ProjectListenerInvokingProjectLoader.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitProject,
+    Success,
+} from "@atomist/automation-client";
+import { ExecuteGoalResult } from "../../api/goal/ExecuteGoalResult";
+import {
+    GoalInvocation,
+    GoalProjectListenerEvent,
+    GoalProjectListenerRegistration,
+} from "../../api/goal/GoalInvocation";
+import { PushListenerInvocation } from "../../api/listener/PushListener";
+import {
+    ProjectLoader,
+    ProjectLoadingParameters,
+    WithLoadedProject,
+} from "../../spi/project/ProjectLoader";
+import { updateGoal } from "../goal/storeGoals";
+import { serializeResult } from "../misc/result";
+
+/**
+ * ProjectLoader implementation that invokes GoalProjectListener instances on the loaded project.
+ * Can be used to restore state into a project/workspace area.
+ */
+export class ProjectListenerInvokingProjectLoader implements ProjectLoader {
+
+    constructor(private readonly gi: GoalInvocation,
+                private readonly listeners: GoalProjectListenerRegistration[]) {
+    }
+
+    public async doWithProject(params: ProjectLoadingParameters, action: WithLoadedProject): Promise<any> {
+        return this.gi.configuration.sdm.projectLoader.doWithProject(params, async p => {
+
+            let result;
+            try {
+
+                // invoke the before_action listeners
+                const beforeResult = await this.invokeListeners(p, GoalProjectListenerEvent.before_action);
+                if (beforeResult && beforeResult.code !== 0) {
+                    return beforeResult;
+                }
+
+                // invoke the wrapped action
+                result = await action(p);
+
+            } catch (err) {
+                throw err;
+            } finally {
+                // invoke the before_action listeners
+                const afterResult = await this.invokeListeners(p, GoalProjectListenerEvent.after_action);
+                if (afterResult && afterResult.code !== 0) {
+                    result = afterResult;
+                }
+            }
+            return result;
+        });
+    }
+
+    private async invokeListeners(p: GitProject,
+                                  event: GoalProjectListenerEvent): Promise<ExecuteGoalResult> {
+        const pli: PushListenerInvocation = {
+            addressChannels: this.gi.addressChannels,
+            context: this.gi.context,
+            credentials: this.gi.credentials,
+            id: this.gi.id,
+            project: p,
+            push: this.gi.sdmGoal.push,
+        };
+
+        let result;
+        for (const lr of this.listeners) {
+            if (await lr.pushTest.mapping(pli)) {
+
+                this.gi.progressLog.write("/--");
+                this.gi.progressLog.write(`Invoking project listener: ${lr.name}`);
+
+                await updateGoal(
+                    this.gi.context,
+                    this.gi.sdmGoal,
+                    {
+                        state: this.gi.sdmGoal.state,
+                        phase: lr.name,
+                        description: this.gi.sdmGoal.description,
+                        url: this.gi.sdmGoal.url,
+                    });
+
+                const postResult = await lr.listener(p, this.gi, event);
+
+                this.gi.progressLog.write(`Result: ${serializeResult(postResult)}`);
+                this.gi.progressLog.write("\\--");
+
+                if (postResult && postResult.code !== 0) {
+                    result = postResult;
+                    break;
+                }
+            }
+        }
+        return Success;
+    }
+}

--- a/lib/api/goal/GoalInvocation.ts
+++ b/lib/api/goal/GoalInvocation.ts
@@ -18,6 +18,7 @@ import { GitProject } from "@atomist/automation-client";
 import { ProgressLog } from "../../spi/log/ProgressLog";
 import { RepoContext } from "../context/SdmContext";
 import { SoftwareDeliveryMachineConfiguration } from "../machine/SoftwareDeliveryMachineOptions";
+import { PushTest } from "../mapping/PushTest";
 import { ExecuteGoalResult } from "./ExecuteGoalResult";
 import { Goal } from "./Goal";
 import { SdmGoalEvent } from "./SdmGoalEvent";
@@ -31,6 +32,20 @@ export type ExecuteGoal =
 
 export type PrepareForGoalExecution =
     (p: GitProject, r: GoalInvocation) => Promise<void | ExecuteGoalResult>;
+
+export enum GoalProjectListenerEvent {
+    before_action,
+    after_action,
+}
+
+export type GoalProjectListener =
+    (p: GitProject, r: GoalInvocation, event: GoalProjectListenerEvent) => Promise<void | ExecuteGoalResult>;
+
+export interface GoalProjectListenerRegistration {
+    name: string;
+    listener: GoalProjectListener;
+    pushTest?: PushTest;
+}
 
 export interface GoalInvocation extends RepoContext {
 

--- a/lib/api/goal/support/GoalImplementationMapper.ts
+++ b/lib/api/goal/support/GoalImplementationMapper.ts
@@ -19,7 +19,10 @@ import { RepoContext } from "../../context/SdmContext";
 import { PushListenerInvocation } from "../../listener/PushListener";
 import { PushTest } from "../../mapping/PushTest";
 import { Goal } from "../Goal";
-import { ExecuteGoal } from "../GoalInvocation";
+import {
+    ExecuteGoal,
+    GoalProjectListenerRegistration,
+} from "../GoalInvocation";
 import { ReportProgress } from "../progress/ReportProgress";
 import { SdmGoalEvent } from "../SdmGoalEvent";
 
@@ -32,6 +35,7 @@ export interface GoalImplementation {
     pushTest: PushTest;
     logInterpreter: InterpretLog;
     progressReporter?: ReportProgress;
+    projectListeners: GoalProjectListenerRegistration | GoalProjectListenerRegistration[];
 }
 
 export function isGoalImplementation(f: GoalFulfillment): f is GoalImplementation {

--- a/lib/api/machine/GoalDrivenMachine.ts
+++ b/lib/api/machine/GoalDrivenMachine.ts
@@ -16,7 +16,11 @@
 
 import { InterpretLog } from "../../spi/log/InterpretedLog";
 import { Goal } from "../goal/Goal";
-import { ExecuteGoal } from "../goal/GoalInvocation";
+import {
+    ExecuteGoal,
+    GoalProjectListener,
+    GoalProjectListenerRegistration,
+} from "../goal/GoalInvocation";
 import { Goals } from "../goal/Goals";
 import { ReportProgress } from "../goal/progress/ReportProgress";
 import { GoalImplementationMapper } from "../goal/support/GoalImplementationMapper";
@@ -59,6 +63,7 @@ export interface GoalDrivenMachine<O extends SoftwareDeliveryMachineConfiguratio
                               pushTest: PushTest,
                               logInterpreter: InterpretLog,
                               progressReporter: ReportProgress,
+                              projectListeners: GoalProjectListenerRegistration | GoalProjectListenerRegistration[],
                           }>): this;
 
     /**

--- a/lib/api/mapping/support/commonPushTests.ts
+++ b/lib/api/mapping/support/commonPushTests.ts
@@ -45,7 +45,7 @@ export const FromAtomist: PushTest = pushTest("Push from Atomist", async p =>
  * @param {PushListenerInvocation} p
  * @constructor
  */
-export const AnyPush: PushTest = pushTest("Any push", async p => true);
+export const AnyPush: PushTest = pushTest("Any push", async () => true);
 
 /**
  * Return a PushTest testing for the existence of the given file

--- a/lib/spi/build/Builder.ts
+++ b/lib/spi/build/Builder.ts
@@ -20,6 +20,7 @@ import {
     RemoteRepoRef,
 } from "@atomist/automation-client";
 import { AddressChannels } from "../../api/context/addressChannels";
+import { SoftwareDeliveryMachineConfiguration } from "../../api/machine/SoftwareDeliveryMachineOptions";
 import { LogInterpretation } from "../log/InterpretedLog";
 import { ProgressLog } from "../log/ProgressLog";
 
@@ -47,5 +48,6 @@ export interface Builder extends LogInterpretation {
                   ac: AddressChannels,
                   push: PushThatTriggersBuild,
                   log: ProgressLog,
-                  context: HandlerContext): Promise<any>;
+                  context: HandlerContext,
+                  configuration: SoftwareDeliveryMachineConfiguration): Promise<any>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4679,7 +4679,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {


### PR DESCRIPTION
This allows us to attach listeners to Goals that get called whenever a project is cloned etc. This will let us populate project resources from caches and consistently apply things like compilation before running the actual goal on the project.