### PR TITLE
Add commit-images link to GraphQL

### DIFF
--- a/lib/graphql/fragment/PushFields.graphql
+++ b/lib/graphql/fragment/PushFields.graphql
@@ -25,6 +25,10 @@ fragment PushFields on Push {
       image
       imageName
     }
+    images {
+      image
+      imageName
+    }
     tags {
       name
       description

--- a/lib/graphql/query/CommitForSdmGoal.graphql
+++ b/lib/graphql/query/CommitForSdmGoal.graphql
@@ -23,5 +23,9 @@ query CommitForSdmGoal(
       image
       imageName
     }
+    images {
+      image
+      imageName
+    }
   }
 }


### PR DESCRIPTION
Add the newer images link to commits.  The image link was not removed,
so this is backward compatible.  Update usage of image link to images
in deployer.

Closes #96