### PR TITLE
Replace `Promise<any>` with `Promise<void>`

### DIFF
--- a/lib/api-helper/goal/executeGoal.ts
+++ b/lib/api-helper/goal/executeGoal.ts
@@ -413,11 +413,11 @@ class ProgressReportingProgressLog implements ProgressLog {
         this.name = sdmGoal.name;
     }
 
-    public close(): Promise<any> {
+    public close(): Promise<void> {
         return Promise.resolve();
     }
 
-    public flush(): Promise<any> {
+    public flush(): Promise<void> {
         return Promise.resolve();
     }
 

--- a/lib/api-helper/goal/executeGoal.ts
+++ b/lib/api-helper/goal/executeGoal.ts
@@ -413,16 +413,16 @@ class ProgressReportingProgressLog implements ProgressLog {
         this.name = sdmGoal.name;
     }
 
-    public close(): Promise<void> {
-        return Promise.resolve();
+    public async close(): Promise<void> {
+        return;
     }
 
-    public flush(): Promise<void> {
-        return Promise.resolve();
+    public async flush(): Promise<void> {
+        return;
     }
 
-    public isAvailable(): Promise<boolean> {
-        return Promise.resolve(true);
+    public async isAvailable(): Promise<boolean> {
+        return true;
     }
 
     public write(what: string): void {

--- a/lib/api-helper/goal/storeGoals.ts
+++ b/lib/api-helper/goal/storeGoals.ts
@@ -220,7 +220,7 @@ export async function storeGoalSet(ctx: HandlerContext,
                                    goalSetId: string,
                                    goalSet: string,
                                    sdmGoals: SdmGoalMessage[],
-                                   push: OnPushToAnyBranch.Push): Promise<any> {
+                                   push: OnPushToAnyBranch.Push): Promise<void> {
     const sdmGoalSet: SdmGoalSetMessage = {
         sha: push.after.sha,
         branch: push.branch,

--- a/lib/api-helper/listener/executeAutoInspects.ts
+++ b/lib/api-helper/listener/executeAutoInspects.ts
@@ -174,7 +174,7 @@ function applyCodeInspections(goalInvocation: GoalInvocation,
         return result;
     }
         ;
-};
+}
 
 async function gatherResponsesFromReviewListeners(reviews: ProjectReview[],
                                                   reviewListeners: ReviewListenerRegistration[],

--- a/lib/api-helper/log/DelimitedWriteProgressLogDecorator.ts
+++ b/lib/api-helper/log/DelimitedWriteProgressLogDecorator.ts
@@ -54,12 +54,12 @@ export class DelimitedWriteProgressLogDecorator implements ProgressLog {
         }
     }
 
-    public flush(): Promise<any> {
+    public flush(): Promise<void> {
         this.writeRemainder();
         return this.delegate.flush();
     }
 
-    public close(): Promise<any> {
+    public close(): Promise<void> {
         this.writeRemainder();
         return this.delegate.close();
     }

--- a/lib/api-helper/log/EphemeralProgressLog.ts
+++ b/lib/api-helper/log/EphemeralProgressLog.ts
@@ -40,7 +40,7 @@ class EphemeralProgressLog implements ProgressLog {
         return Promise.resolve();
     }
 
-    public async close(): Promise<any> {
+    public async close(): Promise<void> {
         if (this.writeToLog) {
             logger.info("vvvvvv CLOSED NON-PERSISTENT LOG ------------------------------");
             logger.info(this.log);

--- a/lib/api-helper/log/StringCapturingProgressLog.ts
+++ b/lib/api-helper/log/StringCapturingProgressLog.ts
@@ -26,11 +26,11 @@ export class StringCapturingProgressLog implements ProgressLog {
 
     public log: string = "";
 
-    public close(): Promise<any> {
+    public close(): Promise<void> {
         return Promise.resolve();
     }
 
-    public flush(): Promise<any> {
+    public flush(): Promise<void> {
         return Promise.resolve();
     }
 

--- a/lib/api-helper/log/WriteToAllProgressLog.ts
+++ b/lib/api-helper/log/WriteToAllProgressLog.ts
@@ -28,24 +28,24 @@ export class WriteToAllProgressLog implements ProgressLog {
         this.logs = [log1, log2].concat(others);
     }
 
-    public async isAvailable() {
+    public async isAvailable(): Promise<boolean> {
         return true;
     }
 
-    public write(what: string) {
+    public write(what: string): void {
         this.logs.forEach(log => log.write(what));
     }
 
-    public flush() {
-        return Promise.all(this.logs.map(log => log.flush()));
+    public async flush(): Promise<void> {
+        await Promise.all(this.logs.map(log => log.flush()));
     }
 
-    public close() {
+    public async close(): Promise<void> {
         if (!this.logs) {
             logger.error("This is unexpected! How did I get here without logs?");
             return;
         }
-        return Promise.all(this.logs.map(log => log.close()));
+        await Promise.all(this.logs.map(log => log.close()));
     }
 
     get log(): string {

--- a/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
+++ b/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
@@ -248,14 +248,17 @@ export abstract class AbstractSoftwareDeliveryMachine<O extends SoftwareDelivery
     /**
      * Invoke StartupListeners.
      */
-    public async notifyStartupListeners(): Promise<any> {
+    public async notifyStartupListeners(): Promise<void> {
         const i: AdminCommunicationContext = {
             addressAdmin: this.configuration.sdm.adminAddressChannels || (async msg => {
                 logger.warn("STARTUP PROBLEM: %j", msg);
             }),
             sdm: this,
         };
-        return Promise.all(this.startupListeners.map(l => l(i)));
+        return Promise.all(this.startupListeners.map(l => l(i)))
+            .then(() => {
+                // Empty to return void
+            });
     }
 
     /**

--- a/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
+++ b/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
@@ -250,7 +250,9 @@ export abstract class AbstractSoftwareDeliveryMachine<O extends SoftwareDelivery
      */
     public async notifyStartupListeners(): Promise<any> {
         const i: AdminCommunicationContext = {
-            addressAdmin: this.configuration.sdm.adminAddressChannels || (async msg => logger.warn("STARTUP PROBLEM: %j", msg)),
+            addressAdmin: this.configuration.sdm.adminAddressChannels || (async msg => {
+                logger.warn("STARTUP PROBLEM: %j", msg);
+            }),
             sdm: this,
         };
         return Promise.all(this.startupListeners.map(l => l(i)));

--- a/lib/api-helper/misc/git/GitHubIssueRouter.ts
+++ b/lib/api-helper/misc/git/GitHubIssueRouter.ts
@@ -30,11 +30,11 @@ export class GitHubIssueRouter implements IssueRouter {
 
     public async raiseIssue(credentials: ProjectOperationCredentials,
                             id: RemoteRepoRef,
-                            issue: Issue): Promise<any> {
+                            issue: Issue): Promise<void> {
         if (!isTokenCredentials(credentials)) {
             throw new Error("Only token credentials are supported");
         }
-        return raiseIssue(credentials.token, id, issue);
+        await raiseIssue(credentials.token, id, issue);
     }
 
 }

--- a/lib/api-helper/project/LazyProjectLoader.ts
+++ b/lib/api-helper/project/LazyProjectLoader.ts
@@ -288,7 +288,7 @@ interface QueryablePromise<T> extends Promise<T> {
  * Based on: http://stackoverflow.com/questions/21485545/is-there-a-way-to-tell-if-an-es6-promise-is-fulfilled-rejected-resolved
  * But modified according to the specs of promises : https://promisesaplus.com/
  */
-function makeQueryablePromise<T>(ppromise: Promise<any>): QueryablePromise<T> {
+function makeQueryablePromise<T>(ppromise: Promise<T>): QueryablePromise<T> {
     const promise = ppromise as any;
     // Don't modify any promise that has been already modified.
     if (promise.isResolved) {

--- a/lib/api-helper/project/ProjectListenerInvokingProjectLoader.ts
+++ b/lib/api-helper/project/ProjectListenerInvokingProjectLoader.ts
@@ -45,7 +45,6 @@ export class ProjectListenerInvokingProjectLoader implements ProjectLoader {
 
     public async doWithProject(params: ProjectLoadingParameters, action: WithLoadedProject): Promise<any> {
         return this.gi.configuration.sdm.projectLoader.doWithProject(params, async p => {
-
             let result;
             try {
 

--- a/lib/api-helper/testsupport/fakeContext.ts
+++ b/lib/api-helper/testsupport/fakeContext.ts
@@ -53,22 +53,25 @@ export function fakeContext(workspaceId: string = "T123"): HandlerContext & Auto
     };
 }
 
+/**
+ * Throw it all away
+ */
 class DevNullMessageClient implements MessageClient, SlackMessageClient {
 
-    public async addressChannels(msg: string | SlackMessage, channels: string | string[], options?: MessageOptions): Promise<any> {
-        return {};
+    public async addressChannels(msg: string | SlackMessage, channels: string | string[], options?: MessageOptions): Promise<void> {
+        // Empty to return void
     }
 
-    public async addressUsers(msg: string | SlackMessage, users: string | string[], options?: MessageOptions): Promise<any> {
-        return {};
+    public async addressUsers(msg: string | SlackMessage, users: string | string[], options?: MessageOptions): Promise<void> {
+        // Empty to return void
     }
 
-    public async respond(msg: any, options?: MessageOptions): Promise<any> {
-        return {};
+    public async respond(msg: any, options?: MessageOptions): Promise<void> {
+        // Empty to return void
     }
 
-    public async send(msg: any, destinations: Destination | Destination[], options?: MessageOptions): Promise<any> {
-        return {};
+    public async send(msg: any, destinations: Destination | Destination[], options?: MessageOptions): Promise<void> {
+        // Empty to return void
     }
 
 }

--- a/lib/api-helper/testsupport/fakeContext.ts
+++ b/lib/api-helper/testsupport/fakeContext.ts
@@ -58,20 +58,27 @@ export function fakeContext(workspaceId: string = "T123"): HandlerContext & Auto
  */
 class DevNullMessageClient implements MessageClient, SlackMessageClient {
 
-    public async addressChannels(msg: string | SlackMessage, channels: string | string[], options?: MessageOptions): Promise<void> {
-        // Empty to return void
+    public async addressChannels(msg: string | SlackMessage,
+                                 channels: string | string[],
+                                 options?: MessageOptions): Promise<void> {
+        return;
     }
 
-    public async addressUsers(msg: string | SlackMessage, users: string | string[], options?: MessageOptions): Promise<void> {
-        // Empty to return void
+    public async addressUsers(msg: string | SlackMessage,
+                              users: string | string[],
+                              options?: MessageOptions): Promise<void> {
+        return;
     }
 
-    public async respond(msg: any, options?: MessageOptions): Promise<void> {
-        // Empty to return void
+    public async respond(msg: any,
+                         options?: MessageOptions): Promise<void> {
+        return;
     }
 
-    public async send(msg: any, destinations: Destination | Destination[], options?: MessageOptions): Promise<void> {
-        // Empty to return void
+    public async send(msg: any,
+                      destinations: Destination | Destination[],
+                      options?: MessageOptions): Promise<void> {
+        return;
     }
 
 }

--- a/lib/api/context/AdminCommunicationContext.ts
+++ b/lib/api/context/AdminCommunicationContext.ts
@@ -24,9 +24,6 @@ export interface AdminCommunicationContext {
 
     /**
      * Address the admin of this SDM
-     * @param {string} message
-     * @param args
-     * @return {Promise<any>}
      */
     addressAdmin: AddressChannels;
 

--- a/lib/api/context/addressChannels.ts
+++ b/lib/api/context/addressChannels.ts
@@ -33,7 +33,9 @@ export type AddressChannels = (msg: string | SlackMessage | SlackFileMessage, op
  * Throw away contents. Use when we know that there can be no linked channels.
  * @constructor
  */
-export const AddressNoChannels: AddressChannels = async () => {};
+export const AddressNoChannels: AddressChannels = async () => {
+    // Empty to return void
+};
 
 /**
  * Interface for anything, like a repo, that has associated chat channel information

--- a/lib/api/context/addressChannels.ts
+++ b/lib/api/context/addressChannels.ts
@@ -34,7 +34,7 @@ export type AddressChannels = (msg: string | SlackMessage | SlackFileMessage, op
  * @constructor
  */
 export const AddressNoChannels: AddressChannels = async () => {
-    // Empty to return void
+    return;
 };
 
 /**

--- a/lib/api/context/addressChannels.ts
+++ b/lib/api/context/addressChannels.ts
@@ -27,13 +27,13 @@ import { SlackMessage } from "@atomist/slack-messages";
  * Allows us to address channels for a particular repo or any GraphQL
  * type with channels
  */
-export type AddressChannels = (msg: string | SlackMessage | SlackFileMessage, opts?: MessageOptions) => Promise<any>;
+export type AddressChannels = (msg: string | SlackMessage | SlackFileMessage, opts?: MessageOptions) => Promise<void>;
 
 /**
  * Throw away contents. Use when we know that there can be no linked channels.
  * @constructor
  */
-export const AddressNoChannels: AddressChannels = async () => undefined;
+export const AddressNoChannels: AddressChannels = async () => {};
 
 /**
  * Interface for anything, like a repo, that has associated chat channel information

--- a/lib/api/goal/common/AutoCodeInspection.ts
+++ b/lib/api/goal/common/AutoCodeInspection.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { executeAutoInspects } from "../../../api-helper/listener/executeAutoInspects";
+import {
+    AutoInspectOptions,
+    executeAutoInspects,
+} from "../../../api-helper/listener/executeAutoInspects";
 import { CodeInspectionRegistration } from "../../registration/CodeInspectionRegistration";
 import { ReviewListenerRegistration } from "../../registration/ReviewListenerRegistration";
 import {
@@ -30,21 +33,42 @@ import {
 import { IndependentOfEnvironment } from "../support/environment";
 
 /**
+ * Options to configure the behavior of the AutoCodeInspection goal.
+ */
+export interface AutoCodeInspectionOptions {
+    reportToSlack?: boolean;
+}
+
+const DefaultAutoCodeInspectionOptions: AutoCodeInspectionOptions = {
+    reportToSlack: false,
+};
+
+/**
  * Goal that runs code inspections
  */
 export class AutoCodeInspection
     extends FulfillableGoalWithRegistrationsAndListeners<CodeInspectionRegistration<any, any>, ReviewListenerRegistration> {
 
     constructor(private readonly goalDetailsOrUniqueName: FulfillableGoalDetails | string = DefaultGoalNameGenerator.generateName("code-inspection"),
+                options?: AutoCodeInspectionOptions,
                 ...dependsOn: Goal[]) {
         super({
             ...CodeInspectionDefintion,
             ...getGoalDefinitionFrom(goalDetailsOrUniqueName, DefaultGoalNameGenerator.generateName("code-inspection")),
         }, ...dependsOn);
 
+        const optsToUse = {
+            reportToSlack: DefaultAutoCodeInspectionOptions.reportToSlack,
+            ...options,
+        };
+
         this.addFulfillment({
             name: `code-inspections-${this.definition.uniqueName}`,
-            goalExecutor: executeAutoInspects(this.registrations, this.listeners),
+            goalExecutor: executeAutoInspects({
+                ...optsToUse,
+                registrations: this.registrations,
+                listeners: this.listeners,
+            }),
         });
     }
 }

--- a/lib/api/goal/common/Fingerprint.ts
+++ b/lib/api/goal/common/Fingerprint.ts
@@ -65,7 +65,7 @@ const FingerprintDefinition: GoalDefinition = {
 
 /**
  * Publish the given fingerprint to Atomist in the given team
- * @return {Promise<any>}
+ * @return {Promise<void>}
  */
 const SendFingerprintToAtomist: FingerprintListener = fli => {
     const url = `https://webhook.atomist.com/atomist/fingerprints/teams/${fli.context.workspaceId}`;

--- a/lib/api/listener/StartupListener.ts
+++ b/lib/api/listener/StartupListener.ts
@@ -25,4 +25,4 @@ export type StartupListenerInvocation = AdminCommunicationContext;
 /**
  * Listener invoked on SDM startup
  */
-export type StartupListener = Function1<AdminCommunicationContext, Promise<any>>;
+export type StartupListener = Function1<AdminCommunicationContext, Promise<void>>;

--- a/lib/api/registration/AutoInspectRegistration.ts
+++ b/lib/api/registration/AutoInspectRegistration.ts
@@ -43,7 +43,7 @@ export interface AutoInspectRegistration<R, PARAMS = NoParameters> extends PushS
      * PushImpactResponse to demand approval or fail goals.
      * @param {R} result
      * @param {ParametersInvocation<PARAMS>} ci
-     * @return {Promise<any>}
+     * @return {Promise<void>}
      */
     onInspectionResult?(result: R, ci: ParametersInvocation<PARAMS>): Promise<PushImpactResponse | void>;
 }

--- a/lib/api/registration/CodeInspectionRegistration.ts
+++ b/lib/api/registration/CodeInspectionRegistration.ts
@@ -58,9 +58,9 @@ export interface CodeInspectionActions<R, PARAMS> {
      * React to computed values from running across one or more projects
      * @param {R[]} results
      * @param ci context
-     * @return {Promise<any>}
+     * @return {Promise<void>}
      */
-    onInspectionResults?(results: Array<CodeInspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+    onInspectionResults?(results: Array<CodeInspectionResult<R>>, ci: CommandListenerInvocation<PARAMS>): Promise<void>;
 }
 
 /**

--- a/lib/api/registration/CodeTransformRegistration.ts
+++ b/lib/api/registration/CodeTransformRegistration.ts
@@ -42,9 +42,9 @@ export interface CodeTransformRegistration<PARAMS = NoParameters>
      * React to results from running transform across one or more projects
      * @param results
      * @param ci context
-     * @return {Promise<any>}
+     * @return {Promise<void>}
      */
-    onTransformResults?(results: TransformResult[], ci: CommandListenerInvocation<PARAMS>): Promise<any>;
+    onTransformResults?(results: TransformResult[], ci: CommandListenerInvocation<PARAMS>): Promise<void>;
 
 }
 

--- a/lib/spi/build/Builder.ts
+++ b/lib/spi/build/Builder.ts
@@ -49,5 +49,5 @@ export interface Builder extends LogInterpretation {
                   push: PushThatTriggersBuild,
                   log: ProgressLog,
                   context: HandlerContext,
-                  configuration: SoftwareDeliveryMachineConfiguration): Promise<any>;
+                  configuration: SoftwareDeliveryMachineConfiguration): Promise<void>;
 }

--- a/lib/spi/deploy/Deployer.ts
+++ b/lib/spi/deploy/Deployer.ts
@@ -34,9 +34,9 @@ export interface Deployer<T extends TargetInfo = TargetInfo, U extends Deploymen
 
     /**
      * Remove a deployment. Very useful for project cleanup
-     * @return {Promise<any>}
+     * @return {Promise<void>}
      */
-    undeploy(ti: T, deployment: U, log: ProgressLog): Promise<any>;
+    undeploy(ti: T, deployment: U, log: ProgressLog): Promise<void>;
 
     /**
      * Find all deployments of the artifact or app

--- a/lib/spi/issue/IssueRouter.ts
+++ b/lib/spi/issue/IssueRouter.ts
@@ -30,9 +30,9 @@ export interface IssueRouter {
      * @param {ProjectOperationCredentials} credentials
      * @param {RemoteRepoRef} id
      * @param {Issue} issue
-     * @return {Promise<any>}
+     * @return {Promise<void>}
      */
     raiseIssue(credentials: ProjectOperationCredentials,
                id: RemoteRepoRef,
-               issue: Issue): Promise<any>;
+               issue: Issue): Promise<void>;
 }

--- a/lib/spi/log/ProgressLog.ts
+++ b/lib/spi/log/ProgressLog.ts
@@ -32,9 +32,9 @@ export interface ProgressLog {
 
     write(what: string): void;
 
-    flush(): Promise<any>;
+    flush(): Promise<void>;
 
-    close(): Promise<any>;
+    close(): Promise<void>;
 
     /**
      * Some implementations expose their log as a string.

--- a/package-lock.json
+++ b/package-lock.json
@@ -912,7 +912,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2432,7 +2431,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3419,14 +3418,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3441,20 +3438,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3571,8 +3565,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3584,7 +3577,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3599,7 +3591,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3607,14 +3598,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3633,7 +3622,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3714,8 +3702,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3727,7 +3714,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3849,7 +3835,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5282,8 +5267,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lower-case": {
       "version": "1.1.4",
@@ -5968,7 +5952,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6293,8 +6276,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -6378,7 +6360,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6425,8 +6406,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -6692,8 +6672,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/test/api-helper/listener/executeAutoInspect.test.ts
+++ b/test/api-helper/listener/executeAutoInspect.test.ts
@@ -96,10 +96,14 @@ describe("executeAutoInspects", () => {
         const p = InMemoryProject.from(id);
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithApproval(reviewEvents);
-        const ge = executeAutoInspects([HatesTheWorld], [{
-            name: "thing",
-            listener: l,
-        }]);
+        const ge = executeAutoInspects({
+            registrations: [HatesTheWorld],
+            listeners: [{
+                name: "thing",
+                listener: l,
+            }],
+            reportToSlack: true,
+        });
         const r = await ge(fakeGoalInvocation(id, {
             projectLoader: new SingleProjectLoader(p),
         } as any)) as ExecuteGoalResult;
@@ -114,10 +118,14 @@ describe("executeAutoInspects", () => {
         const p = InMemoryProject.from(id, new InMemoryProjectFile("thing", "1"));
         const reviewEvents: ReviewListenerInvocation[] = [];
         const l = loggingReviewListenerWithApproval(reviewEvents);
-        const ge = executeAutoInspects([HatesTheWorld], [{
-            name: "thing",
-            listener: l,
-        }]);
+        const ge = executeAutoInspects({
+            registrations: [HatesTheWorld],
+            listeners: [{
+                name: "thing",
+                listener: l,
+            }],
+            reportToSlack: true,
+        });
         const rwlc = fakeGoalInvocation(id, {
             projectLoader: new SingleProjectLoader(p),
         } as any);
@@ -148,7 +156,7 @@ describe("executeAutoInspects", () => {
                 assert(!ci);
             },
         };
-        const ge = executeAutoInspects([reg], []);
+        const ge = executeAutoInspects({ registrations: [reg], listeners: [], reportToSlack: true });
 
         await ge(rwlc);
         assert.deepEqual(errors, []);
@@ -159,10 +167,13 @@ describe("executeAutoInspects", () => {
         const p = InMemoryProject.from(id, new InMemoryProjectFile("thing", "1"));
         const reviewEvents: ReviewListenerInvocation[] = [];
         const listener = loggingReviewListenerWithoutApproval(reviewEvents);
-        const ge = executeAutoInspects([HatesTheWorld], [{
-            name: "thing",
-            listener,
-        }]);
+        const ge = executeAutoInspects({
+            registrations: [HatesTheWorld],
+            listeners: [{
+                name: "thing",
+                listener,
+            }], reportToSlack: true,
+        });
         const rwlc = fakeGoalInvocation(id, {
             projectLoader: new SingleProjectLoader(p),
         } as any);
@@ -179,10 +190,12 @@ describe("executeAutoInspects", () => {
         const p = InMemoryProject.from(id, new InMemoryProjectFile("thing", "1"));
         const reviewEvents: ReviewListenerInvocation[] = [];
         const listener = loggingReviewListenerFailingTheGoal(reviewEvents);
-        const ge = executeAutoInspects([HatesTheWorld], [{
-            name: "thing",
-            listener,
-        }]);
+        const ge = executeAutoInspects({
+            registrations: [HatesTheWorld], listeners: [{
+                name: "thing",
+                listener,
+            }], reportToSlack: true,
+        });
         const rwlc = fakeGoalInvocation(id, {
             projectLoader: new SingleProjectLoader(p),
         } as any);
@@ -198,11 +211,13 @@ describe("executeAutoInspects", () => {
         const p = InMemoryProject.from(id, new InMemoryProjectFile("thing", "1"));
         const reviewEvents: ReviewListenerInvocation[] = [];
         const listener = loggingReviewListenerWithApproval(reviewEvents);
-        const ge = executeAutoInspects([HatesTheWorld, JustTheOne],
-            [{
+        const ge = executeAutoInspects({
+            registrations: [HatesTheWorld, JustTheOne],
+            listeners: [{
                 name: "thing",
                 listener,
-            }]);
+            }], reportToSlack: true,
+        });
         const rwlc = fakeGoalInvocation(id, {
             projectLoader: new SingleProjectLoader(p),
         } as any);

--- a/test/api-helper/log/DelimitedWriteProgressLogDecorator.test.ts
+++ b/test/api-helper/log/DelimitedWriteProgressLogDecorator.test.ts
@@ -25,11 +25,11 @@ class ListProgressLog implements ProgressLog {
 
     public readonly name: string = "ListProgressLog";
 
-    public close(): Promise<any> {
+    public close(): Promise<void> {
         return Promise.resolve();
     }
 
-    public flush(): Promise<any> {
+    public flush(): Promise<void> {
         return Promise.resolve();
     }
 

--- a/test/api-helper/log/DelimitedWriteProgressLogDecorator.test.ts
+++ b/test/api-helper/log/DelimitedWriteProgressLogDecorator.test.ts
@@ -25,20 +25,20 @@ class ListProgressLog implements ProgressLog {
 
     public readonly name: string = "ListProgressLog";
 
-    public close(): Promise<void> {
-        return Promise.resolve();
+    public async close(): Promise<void> {
+        return;
     }
 
-    public flush(): Promise<void> {
-        return Promise.resolve();
+    public async flush(): Promise<void> {
+        return;
     }
 
     public write(what: string): void {
         this.logList.push(what);
     }
 
-    public isAvailable(): Promise<boolean> {
-        return Promise.resolve(true);
+    public async isAvailable(): Promise<boolean> {
+        return true;
     }
 }
 


### PR DESCRIPTION
Certain types and functions--e.g. `AddressChannels`--returned `Promise<any>`. This could result in unexpected errors: For example, a `CodeTransform` that returned `sdmContext.addressChannels(message)` would cause a failure in editor infrastructure.

The impact of this change on user code should be minor and fairly clear. It feels like a worthwhile tightening before 1.0.0.GA.