### PR TITLE
Make `code` on `ExecuteGoalResult` optional

### DIFF
--- a/lib/api/goal/ExecuteGoalResult.ts
+++ b/lib/api/goal/ExecuteGoalResult.ts
@@ -70,10 +70,32 @@ export interface ExecuteGoalResult extends GoalDetails {
      * 0 is success; non-zero exit codes will mark the goal as failed,
      * if state is not defined
      */
-    code: number;
+    code?: number;
 
     /**
      * The simple text message describing the result
      */
     message?: string;
+}
+
+/**
+ * Assert if a given ExecuteGoalResult describe a successful result
+ * @param result
+ */
+export function isSuccess(result: ExecuteGoalResult | void): boolean {
+    if (result) {
+        if (!result.code) {
+            return true;
+        }
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Assert if a given ExecuteGoalResult describe a failure result
+ * @param result
+ */
+export function isFailure(result: ExecuteGoalResult | void): boolean {
+    return !isSuccess(result);
 }

--- a/lib/api/goal/ExecuteGoalResult.ts
+++ b/lib/api/goal/ExecuteGoalResult.ts
@@ -62,12 +62,15 @@ export interface GoalDetails {
 }
 
 /**
- * Result from goal execution
+ * Result from goal execution.
+ *
+ * Instead of returning ExecuteGoalResult, it is ok to throw an Error
+ * to signal errors during goal execution.
  */
 export interface ExecuteGoalResult extends GoalDetails {
 
     /**
-     * 0 is success; non-zero exit codes will mark the goal as failed,
+     * 0, undefined or null is success; non-zero exit codes will mark the goal as failed,
      * if state is not defined
      */
     code?: number;

--- a/test/api-helper/goal/executeGoal.test.ts
+++ b/test/api-helper/goal/executeGoal.test.ts
@@ -129,7 +129,8 @@ describe("executeGoal", () => {
                 goal: fakeGoal,
                 sdmGoal: fakeSdmGoal,
                 progressLog: {
-                    write: () => { /** empty */ },
+                    write: () => { /** empty */
+                    },
                 },
                 configuration: {
                     sdm: {

--- a/test/api/goal/ExecuteGoalResult.test.ts
+++ b/test/api/goal/ExecuteGoalResult.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import {
+    isFailure,
+    isSuccess,
+} from "../../../lib/api/goal/ExecuteGoalResult";
+
+describe("ExecuteGoalResult", () => {
+
+    describe("isSuccess/isFailure", () => {
+
+        it("should correctly detect success from undefined", () => {
+            assert.strictEqual(isSuccess(undefined), true);
+            assert.strictEqual(isFailure(undefined), false);
+        });
+
+        it("should correctly detect success from result without code", () => {
+            assert.strictEqual(isSuccess({ message: "This is a test " }), true);
+            assert.strictEqual(isFailure({ message: "This is a test " }), false);
+        });
+
+        it("should correctly detect success from result with code", () => {
+            assert.strictEqual(isSuccess({ code: 0, message: "This is a test " }), true);
+            assert.strictEqual(isFailure({ code: 0, message: "This is a test " }), false);
+        });
+
+        it("should correctly detect success from result with null code", () => {
+            assert.strictEqual(isSuccess({ code: null, message: "This is a test " }), true);
+            assert.strictEqual(isFailure({ code: null, message: "This is a test " }), false);
+        });
+
+        it("should correctly detect success from result with undefined code", () => {
+            assert.strictEqual(isSuccess({ code: undefined, message: "This is a test " }), true);
+            assert.strictEqual(isFailure({ code: undefined, message: "This is a test " }), false);
+        });
+
+        it("should correctly detect failure from result with code", () => {
+            assert.strictEqual(isSuccess({ code: 1, message: "This is a test " }), false);
+            assert.strictEqual(isFailure({ code: 1, message: "This is a test " }), true);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Omitting `code` means `success`as does `code: 0`.