### PR TITLE
Handle unknown state when setting goal set state

### DIFF
--- a/lib/api-helper/goal/storeGoals.ts
+++ b/lib/api-helper/goal/storeGoals.ts
@@ -242,7 +242,7 @@ export async function storeGoalSet(ctx: HandlerContext,
     return ctx.messageClient.send(sdmGoalSet, addressEvent(GoalSetRootType));
 }
 
-export function goalSetState(goals: Array<{ state: SdmGoalState }>): SdmGoalState {
+export function goalSetState(goals: Array<Pick<SdmGoalMessage, "name" | "state">>): SdmGoalState {
     if (goals.some(g => g.state === SdmGoalState.failure)) {
         return SdmGoalState.failure;
     } else if (goals.some(g => g.state === SdmGoalState.canceled)) {
@@ -265,8 +265,11 @@ export function goalSetState(goals: Array<{ state: SdmGoalState }>): SdmGoalStat
         return SdmGoalState.planned;
     } else if (goals.some(g => g.state === SdmGoalState.skipped)) {
         return SdmGoalState.skipped;
-    } else {
+    } else if (goals.every(g => g.state === SdmGoalState.success)) {
         return SdmGoalState.success;
+    } else {
+        const unknowns = goals.filter(g => g.state !== SdmGoalState.success).map(g => `${g.name}:${g.state}`);
+        throw new Error("Unknown goal state(s): " + JSON.stringify(unknowns));
     }
 }
 

--- a/lib/api/goal/common/Queue.ts
+++ b/lib/api/goal/common/Queue.ts
@@ -187,10 +187,10 @@ async function updateGoals(goalSets: InProcessSdmGoalSets.Query,
         .filter(gs => gs.goals.some(g => g.uniqueName === definition.uniqueName));
     if (goalSetsToUpdate.length > 0) {
 
-        const updateGoals = await loadQueueGoals(goalSetsToUpdate, definition, ctx);
+        const queuedGoals = await loadQueueGoals(goalSetsToUpdate, definition, ctx);
 
         for (const goalSetToUpdate of goalSetsToUpdate) {
-            const updGoal = _.maxBy(updateGoals.filter(g => g.goalSetId === goalSetToUpdate.goalSetId), "ts") as SdmGoalEvent;
+            const updGoal = _.maxBy(queuedGoals.filter(g => g.goalSetId === goalSetToUpdate.goalSetId), "ts") as SdmGoalEvent;
             const phase = `at ${goalSetsToUpdate.findIndex(gs => gs.goalSetId === updGoal.goalSetId) + 1}`;
             if (updGoal.state === SdmGoalState.in_process && updGoal.phase !== phase) {
                 await updateGoal(ctx, updGoal, {

--- a/test/api-helper/goal/storeGoals.test.ts
+++ b/test/api-helper/goal/storeGoals.test.ts
@@ -16,14 +16,16 @@
 
 import * as assert from "power-assert";
 import { goalSetState } from "../../../lib/api-helper/goal/storeGoals";
+import { SdmGoalMessage } from "../../../lib/api/goal/SdmGoalMessage";
 import { SdmGoalState } from "../../../lib/typings/types";
 
 describe("storeGoals", () => {
 
     describe("goalSetState", () => {
 
-        function createGoals(...states: string[]): Array<{ state: SdmGoalState }> {
-            return states.map(s => ({ state: s as SdmGoalState }));
+        let i = 0;
+        function createGoals(...states: string[]): Array<Pick<SdmGoalMessage, "name" | "state">> {
+            return states.map(s => ({ name: `goal-${i++}`, state: s as SdmGoalState }));
         }
 
         it("should correctly determine success", () => {
@@ -62,6 +64,11 @@ describe("storeGoals", () => {
             assert.strictEqual(goalSetState(createGoals("waiting_for_pre_approval", "waiting_for_approval", "success")),
                 SdmGoalState.waiting_for_pre_approval);
         });
+
+        it("should throw an error when given an invalid state", () => {
+            assert.throws(() => goalSetState(createGoals("success", "waiting_fer_approval", "success")), /Unknown goal state/);
+        });
+
     });
 
 });

--- a/tslint.json
+++ b/tslint.json
@@ -12,10 +12,9 @@
     "arrow-return-shorthand": true,
     "await-promise": true,
     "curly": true,
-    "cyclomatic-complexity": [
-      true,
-      12
-    ],
+    "cyclomatic-complexity": {
+      "severity": "warning"
+    },
     "deprecation": true,
     "interface-name": [
       true,


### PR DESCRIPTION
Account for bad goal state input by throwing an error, similar to the
`descriptionFromState` function.

Fix some linting issues.

It seemed odd to me to default to "success".