### PR TITLE
Provide spawnLog with consistent spawn interface

### DIFF
--- a/lib/api-helper/command/transform/spawnCodeTransform.ts
+++ b/lib/api-helper/command/transform/spawnCodeTransform.ts
@@ -26,7 +26,7 @@ import {
 import { ProgressLog } from "../../../spi/log/ProgressLog";
 import { LoggingProgressLog } from "../../log/LoggingProgressLog";
 import {
-    spawnAndLog,
+    spawnLog,
     SpawnLogCommand,
     SpawnLogOptions,
     SpawnLogResult,
@@ -71,11 +71,12 @@ export function spawnCodeTransform(commands: SpawnLogCommand[], log: ProgressLog
         log.stripAnsi = true;
         const defaultOptions: SpawnLogOptions = {
             cwd: p.baseDir,
+            log,
         };
         let commandResult: MinSpawnLogResult;
         for (const cmd of commands) {
             try {
-                commandResult = await spawnAndLog(log, cmd.command, cmd.args, { ...defaultOptions, ...cmd.options });
+                commandResult = await spawnLog(cmd.command, cmd.args, { ...defaultOptions, ...cmd.options });
             } catch (e) {
                 e.message = `Uncaught error when running command ${cmd.command}: ${e.message}`;
                 logger.warn(e.message);

--- a/lib/api-helper/goal/executeGoal.ts
+++ b/lib/api-helper/goal/executeGoal.ts
@@ -50,7 +50,7 @@ import { ProgressLog } from "../../spi/log/ProgressLog";
 import { ProjectLoader } from "../../spi/project/ProjectLoader";
 import { SdmGoalState } from "../../typings/types";
 import { WriteToAllProgressLog } from "../log/WriteToAllProgressLog";
-import { spawnAndLog } from "../misc/child_process";
+import { spawnLog } from "../misc/child_process";
 import { toToken } from "../misc/credentials/toToken";
 import { stringifyError } from "../misc/errorPrinting";
 import { reportFailureInterpretation } from "../misc/reportFailureInterpretation";
@@ -226,10 +226,11 @@ export async function executeHook(rules: { projectLoader: ProjectLoader },
                     ATOMIST_REPO: sdmGoal.push.repo.name,
                     ATOMIST_OWNER: sdmGoal.push.repo.owner,
                 },
+                log: progressLog,
             };
 
             const cmd = path.join(p.baseDir, ".atomist", "hooks", hook);
-            let result: HandlerResult = await spawnAndLog(progressLog, cmd, [], opts);
+            let result: HandlerResult = await spawnLog(cmd, [], opts);
             if (!result) {
                 result = Success;
             }

--- a/lib/api-helper/project/withProject.ts
+++ b/lib/api-helper/project/withProject.ts
@@ -29,7 +29,7 @@ import { ProgressLog } from "../../spi/log/ProgressLog";
 import {
     execPromise,
     ExecPromiseResult,
-    spawnAndLog,
+    spawnLog,
     SpawnLogOptions,
     SpawnLogResult,
 } from "../misc/child_process";
@@ -41,25 +41,27 @@ import { ProjectListenerInvocation } from "./../../api/listener/ProjectListener"
 export interface ChildProcessOnProject {
 
     /**
-     * Spawn a child process, by default setting cwd to the directory of the local
-     * project and using the progressLog of GoalInvocation as logger.
-     * See spawnAndLog for more details.
-     * @param {string} cmd
-     * @param {string | string[]} args
-     * @param {SpawnLogOptions} opts
-     * @param {ProgressLog} log
-     * @returns {Promise<SpawnLogResult>}
+     * Spawn a child process, by default setting cwd to the directory
+     * of the local project and using the progressLog of
+     * GoalInvocation as logger.  Any `cwd` passed in the options
+     * overrides the default.  See [[spawnLog]] for more details.
+     *
+     * @param cmd Command to spawn
+     * @param args Arguments to command
+     * @param opts Spawn options
+     * @returns Command result
      */
-    spawn(cmd: string, args?: string | string[], opts?: SpawnLogOptions, log?: ProgressLog): Promise<SpawnLogResult>;
+    spawn(cmd: string, args?: string | string[], opts?: SpawnLogOptions): Promise<SpawnLogResult>;
 
     /**
-     * Spawn a child process, by default setting cw to the directory of the local
-     * project.
-     * See execPromise for more details.
-     * @param {string} cmd
-     * @param {string | string[]} args
-     * @param {SpawnSyncOptions} opts
-     * @returns {Promise<ExecPromiseResult>}
+     * Spawn a child process, by default setting cwd to the directory
+     * of the local project.  Any `cwd` passed in the options
+     * overrides the default.  See [[execPromise]] for more details.
+     *
+     * @param cmd Command to spawn
+     * @param args Arguments to command
+     * @param opts Spawn options
+     * @returns Command standard output and standard error
      */
     exec(cmd: string, args?: string | string[], opts?: SpawnSyncOptions): Promise<ExecPromiseResult>;
 }
@@ -83,13 +85,13 @@ export function doWithProject(action: (pa: ProjectAwareGoalInvocation) => Promis
         function spawn(p: GitProject) {
             return (cmd: string,
                     args: string | string[] = [],
-                    opts: SpawnLogOptions = {},
-                    log: ProgressLog = progressLog) => {
+                    opts?: SpawnLogOptions) => {
                 const optsToUse: SpawnLogOptions = {
                     cwd: p.baseDir,
+                    log: progressLog,
                     ...opts,
                 };
-                return spawnAndLog(log, cmd, toStringArray(args), optsToUse);
+                return spawnLog(cmd, toStringArray(args), optsToUse);
             };
         }
 

--- a/test/api-helper/project/withProject.test.ts
+++ b/test/api-helper/project/withProject.test.ts
@@ -44,8 +44,8 @@ describe("withProject", () => {
                 },
             } as any);
             const action = async (gi: ProjectAwareGoalInvocation) => {
-                const r = await gi.exec("pwd");
-                assert(!!r.stdout);
+                const r = await gi.exec("node", ["-e", "console.log(process.cwd());"]);
+                assert(r.stdout === process.cwd() + "\n");
                 assert(await gi.project.hasFile("foo"));
                 assert.strictEqual(gi.credentials, fgi.credentials);
                 return { code: 0 };


### PR DESCRIPTION
Rather than have a separate log argument, just make the log option
property not optional.  Update code throughout.