### PR TITLE
Allow state computation in push rule evaluation

### DIFF
--- a/lib/api/dsl/goalContribution.ts
+++ b/lib/api/dsl/goalContribution.ts
@@ -45,13 +45,17 @@ export interface InvocationState {
     [key: string]: any;
 }
 
+/**
+ * Add state to an invocation. Only available in memory.
+ */
 export interface StatefulInvocation extends SdmContext {
 
     state?: InvocationState;
 }
 
 /**
- * Within evaluation of push rules we can manage state to a push.
+ * Within evaluation of push rules we can manage state on a push.
+ * This interface allows state. This state will not be persisted.
  */
 export interface StatefulPushListenerInvocation extends PushListenerInvocation, StatefulInvocation {
 

--- a/lib/api/dsl/goalContribution.ts
+++ b/lib/api/dsl/goalContribution.ts
@@ -21,10 +21,21 @@ import { Locking } from "../goal/common/Locking";
 import { Goal } from "../goal/Goal";
 import { Goals } from "../goal/Goals";
 import { PushListenerInvocation } from "../listener/PushListener";
-import { GoalSetter, GoalSettingCompositionStyle, GoalSettingStructure } from "../mapping/GoalSetter";
-import { mapMapping, Mapping, NeverMatch } from "../mapping/Mapping";
+import {
+    GoalSetter,
+    GoalSettingCompositionStyle,
+    GoalSettingStructure,
+} from "../mapping/GoalSetter";
+import {
+    mapMapping,
+    Mapping,
+    NeverMatch,
+} from "../mapping/Mapping";
 import { Predicated } from "../mapping/PredicateMapping";
-import { GoalComponent, toGoals } from "./GoalComponent";
+import {
+    GoalComponent,
+    toGoals,
+} from "./GoalComponent";
 
 export interface GoalContribution<F> extends Mapping<F, GoalComponent>, Predicated<F> {
 

--- a/lib/api/dsl/goalContribution.ts
+++ b/lib/api/dsl/goalContribution.ts
@@ -58,13 +58,13 @@ export interface StatefulPushListenerInvocation extends PushListenerInvocation, 
 }
 
 /**
- * Enrich the push, enhancing its state
+ * Enrich the invocation, enhancing its state
  * @param {(f: (F & StatefulInvocation)) => Promise<void>} compute
  * @return {GoalContribution<F>}
  */
-export function enrichPush<F>(compute: (f: (F & StatefulInvocation)) => Promise<void>): GoalContribution<F> {
+export function enrichInvocation<F>(compute: (f: (F & StatefulInvocation)) => Promise<void>): GoalContribution<F> {
     return {
-        name: "enrichPush",
+        name: "enrichInvocation",
         mapping: async f => {
             const withState = f as F & StatefulInvocation;
             if (!withState.state) {

--- a/lib/api/dsl/goalContribution.ts
+++ b/lib/api/dsl/goalContribution.ts
@@ -59,10 +59,10 @@ export interface StatefulPushListenerInvocation extends PushListenerInvocation, 
 
 /**
  * Enrich the invocation, enhancing its state
- * @param {(f: (F & StatefulInvocation)) => Promise<void>} compute
+ * @param {(f: (F & StatefulInvocation)) => Promise<InvocationState>} compute additional state
  * @return {GoalContribution<F>}
  */
-export function enrichInvocation<F>(compute: (f: (F & StatefulInvocation)) => Promise<void>): GoalContribution<F> {
+export function enrichInvocation<F>(compute: (f: (F & StatefulInvocation)) => Promise<InvocationState>): GoalContribution<F> {
     return {
         name: "enrichInvocation",
         mapping: async f => {
@@ -70,7 +70,8 @@ export function enrichInvocation<F>(compute: (f: (F & StatefulInvocation)) => Pr
             if (!withState.state) {
                 withState.state = {};
             }
-            await compute(withState);
+            const additionalState = await compute(withState);
+            _.merge(withState.state, additionalState);
             return undefined;
         },
     };

--- a/lib/api/dsl/goalContribution.ts
+++ b/lib/api/dsl/goalContribution.ts
@@ -21,17 +21,17 @@ import { Locking } from "../goal/common/Locking";
 import { Goal } from "../goal/Goal";
 import { Goals } from "../goal/Goals";
 import { PushListenerInvocation } from "../listener/PushListener";
-import { GoalSetter, GoalSettingCompositionStyle, GoalSettingStructure, } from "../mapping/GoalSetter";
-import { mapMapping, Mapping, NeverMatch, } from "../mapping/Mapping";
+import { GoalSetter, GoalSettingCompositionStyle, GoalSettingStructure } from "../mapping/GoalSetter";
+import { mapMapping, Mapping, NeverMatch } from "../mapping/Mapping";
 import { Predicated } from "../mapping/PredicateMapping";
-import { GoalComponent, toGoals, } from "./GoalComponent";
+import { GoalComponent, toGoals } from "./GoalComponent";
 
 export interface GoalContribution<F> extends Mapping<F, GoalComponent>, Predicated<F> {
 
 }
 
 export interface InvocationState {
-    [key: string]: any
+    [key: string]: any;
 }
 
 export interface StatefulInvocation extends SdmContext {
@@ -57,11 +57,11 @@ export function enrichPush<F>(compute: (f: (F & StatefulInvocation)) => Promise<
         mapping: async f => {
             const withState = f as F & StatefulInvocation;
             if (!withState.state) {
-                withState.state = {}
+                withState.state = {};
             }
             await compute(withState);
             return undefined;
-        }
+        },
     };
 }
 

--- a/lib/api/dsl/goalDsl.ts
+++ b/lib/api/dsl/goalDsl.ts
@@ -73,9 +73,9 @@ export class GoalSetterMapping extends PushRule<Goals> {
  * @param {PushTest} guard1
  * @param {PushTest} guards
  */
-export function whenPushSatisfies(
-    guard1: PredicateMappingTerm<PushListenerInvocation>,
-    ...guards: Array<PredicateMappingTerm<PushListenerInvocation>>): GoalSetterMapping {
+export function whenPushSatisfies<P extends PushListenerInvocation = PushListenerInvocation>(
+    guard1: PredicateMappingTerm<P>,
+    ...guards: Array<PredicateMappingTerm<P>>): GoalSetterMapping {
     return new GoalSetterMapping(toPredicateMapping(guard1), guards.map(toPredicateMapping));
 }
 

--- a/test/api/dsl/goalContribution.test.ts
+++ b/test/api/dsl/goalContribution.test.ts
@@ -181,7 +181,7 @@ describe("goalContribution", () => {
             const mg = suggestAction({ message: "sendSomeMessage", displayName: "Sending message" });
             const old = whenPushSatisfies(() => true).itMeans("thing").setGoals(SomeGoalSet);
             let gs = enrichGoalSetters(old,
-                enrichInvocation(async pu => { pu.state.name = "tony"; }),
+                enrichInvocation(async pu => ({ name: "tony" })),
                 whenPushSatisfies<StatefulPushListenerInvocation>(async pu => pu.state.name === "tony").setGoals(mg));
             gs = enrichGoalSetters(gs,
                 onAnyPush().setGoals(FingerprintGoal));

--- a/test/api/dsl/goalContribution.test.ts
+++ b/test/api/dsl/goalContribution.test.ts
@@ -25,7 +25,8 @@ import { fakePush } from "../../../lib/api-helper/testsupport/fakePush";
 import {
     enrichGoalSetters,
     enrichPush,
-    goalContributors, StatefulPushListenerInvocation,
+    goalContributors,
+    StatefulPushListenerInvocation,
 } from "../../../lib/api/dsl/goalContribution";
 import {
     onAnyPush,

--- a/test/api/dsl/goalContribution.test.ts
+++ b/test/api/dsl/goalContribution.test.ts
@@ -23,8 +23,8 @@ import { isGitHubRepoRef } from "@atomist/automation-client/lib/operations/commo
 import * as assert from "power-assert";
 import { fakePush } from "../../../lib/api-helper/testsupport/fakePush";
 import {
-    enrichPush,
     enrichGoalSetters,
+    enrichPush,
     goalContributors, StatefulPushListenerInvocation,
 } from "../../../lib/api/dsl/goalContribution";
 import {
@@ -180,7 +180,7 @@ describe("goalContribution", () => {
             const mg = suggestAction({ message: "sendSomeMessage", displayName: "Sending message" });
             const old = whenPushSatisfies(() => true).itMeans("thing").setGoals(SomeGoalSet);
             let gs = enrichGoalSetters(old,
-                enrichPush(async pu => { pu.state.name = "tony" }),
+                enrichPush(async pu => { pu.state.name = "tony"; }),
                 whenPushSatisfies<StatefulPushListenerInvocation>(async pu => pu.state.name === "tony").setGoals(mg));
             gs = enrichGoalSetters(gs,
                 onAnyPush().setGoals(FingerprintGoal));

--- a/test/api/dsl/goalContribution.test.ts
+++ b/test/api/dsl/goalContribution.test.ts
@@ -179,17 +179,16 @@ describe("goalContribution", () => {
 
         it("should allow state", async () => {
             const mg = suggestAction({ message: "sendSomeMessage", displayName: "Sending message" });
-            const old = whenPushSatisfies(() => true).itMeans("thing").setGoals(SomeGoalSet);
-            let gs = enrichGoalSetters(old,
+            let gs = goalContributors(
                 enrichInvocation(async pu => ({ name: "tony" })),
                 whenPushSatisfies<StatefulPushListenerInvocation>(async pu => pu.state.name === "tony").setGoals(mg));
             gs = enrichGoalSetters(gs,
                 onAnyPush().setGoals(FingerprintGoal));
             const p = fakePush();
             const goals: Goals = await gs.mapping(p);
-            assert.equal(goals.goals.length, 3);
-            assert.deepEqual(goals.goals, SomeGoalSet.goals.concat([mg, FingerprintGoal] as any));
-            assert.equal(goals.name, "SomeGoalSet, Sending message, fingerprint");
+            assert.equal(goals.goals.length, 2);
+            assert.deepEqual(goals.goals, [mg, FingerprintGoal]);
+            assert.equal(goals.name, "Sending message, fingerprint");
         });
 
     });

--- a/test/api/dsl/goalContribution.test.ts
+++ b/test/api/dsl/goalContribution.test.ts
@@ -24,7 +24,7 @@ import * as assert from "power-assert";
 import { fakePush } from "../../../lib/api-helper/testsupport/fakePush";
 import {
     enrichGoalSetters,
-    enrichPush,
+    enrichInvocation,
     goalContributors,
     StatefulPushListenerInvocation,
 } from "../../../lib/api/dsl/goalContribution";
@@ -181,7 +181,7 @@ describe("goalContribution", () => {
             const mg = suggestAction({ message: "sendSomeMessage", displayName: "Sending message" });
             const old = whenPushSatisfies(() => true).itMeans("thing").setGoals(SomeGoalSet);
             let gs = enrichGoalSetters(old,
-                enrichPush(async pu => { pu.state.name = "tony"; }),
+                enrichInvocation(async pu => { pu.state.name = "tony"; }),
                 whenPushSatisfies<StatefulPushListenerInvocation>(async pu => pu.state.name === "tony").setGoals(mg));
             gs = enrichGoalSetters(gs,
                 onAnyPush().setGoals(FingerprintGoal));


### PR DESCRIPTION
When evaluating contributor-style push rules, ordering is guaranteed. And efficiency can often be improved by only performing expensive computations once. 

This PR allows state to be added to the `PushListenerInvocation` used within this push rule computation mode and referenced in subsequent push rules, for greater efficiency.