### PR TITLE
Use TypeScript Record type to enforce matching of parameter interface with definitions

### DIFF
--- a/lib/api-helper/machine/handlerRegistrations.ts
+++ b/lib/api-helper/machine/handlerRegistrations.ts
@@ -359,7 +359,7 @@ function addParametersDefinedInBuilder<PARAMS>(c: CommandRegistration<PARAMS>) {
                 paramsInstance = {};
                 paramsInstance.__kind = "command-handler";
             }
-            const paramListing = toParametersListing(c.parameters);
+            const paramListing = toParametersListing(c.parameters as any);
             paramListing.parameters.forEach(p => {
                 paramsInstance[p.name] = p.defaultValue;
                 declareParameter(paramsInstance, p.name, p);
@@ -378,12 +378,12 @@ function isMappedParameterOrSecretDeclaration(x: any): x is MappedParameterOrSec
     return !!maybe && !!maybe.declarationType;
 }
 
-function isParametersListing(p: ParametersDefinition): p is ParametersListing {
+function isParametersListing(p: ParametersDefinition<any>): p is ParametersListing {
     const maybe = p as ParametersListing;
     return maybe.parameters !== undefined && maybe.mappedParameters !== undefined;
 }
 
-export function toParametersListing(p: ParametersDefinition): ParametersListing {
+export function toParametersListing(p: ParametersDefinition<any>): ParametersListing {
     if (isParametersListing(p)) {
         return p;
     }

--- a/lib/api/registration/CommandRegistration.ts
+++ b/lib/api/registration/CommandRegistration.ts
@@ -41,7 +41,7 @@ export interface CommandRegistration<PARAMS> {
      * Define parameters used by this command. Alternative to using
      * paramsMaker: Do not supply both.
      */
-    parameters?: ParametersDefinition;
+    parameters?: ParametersDefinition<PARAMS>;
 
     intent?: string | string[];
     tags?: string | string[];

--- a/lib/api/registration/ParametersDefinition.ts
+++ b/lib/api/registration/ParametersDefinition.ts
@@ -16,7 +16,7 @@
 
 import { BaseParameter } from "@atomist/automation-client";
 
-export type ParametersDefinition = ParametersListing | ParametersObject;
+export type ParametersDefinition<PARAMS> = ParametersListing | ParametersObject<PARAMS>;
 
 /**
  * Interface mixed in with BaseParameter to allow adding a default value to a parameter.
@@ -25,13 +25,13 @@ export type ParametersDefinition = ParametersListing | ParametersObject;
  */
 export interface HasDefaultValue { defaultValue?: any; }
 
+export type ParametersObjectValue = (BaseParameter & HasDefaultValue) | MappedParameterOrSecretDeclaration;
+
 /**
  * Object with properties defining parameters. Useful for combination
  * via spreads.
  */
-export interface ParametersObject {
-    [name: string]: (BaseParameter & HasDefaultValue) | MappedParameterOrSecretDeclaration;
-}
+export type ParametersObject<PARAMS, K extends keyof PARAMS = keyof PARAMS> = Record<K, ParametersObjectValue>;
 
 export enum DeclarationType {
     mapped = "mapped",

--- a/lib/api/registration/ParametersDefinition.ts
+++ b/lib/api/registration/ParametersDefinition.ts
@@ -16,7 +16,7 @@
 
 import { BaseParameter } from "@atomist/automation-client";
 
-export type ParametersDefinition<PARAMS> = ParametersListing | ParametersObject<PARAMS>;
+export type ParametersDefinition<PARAMS = any> = ParametersListing | ParametersObject<PARAMS>;
 
 /**
  * Interface mixed in with BaseParameter to allow adding a default value to a parameter.

--- a/test/api/registration/commandRegistration.test.ts
+++ b/test/api/registration/commandRegistration.test.ts
@@ -185,7 +185,7 @@ describe("command registrations", () => {
     });
 
     it("parameter builder should set mapped parameter and secret via indexed property, with spread", () => {
-        const halfOfParameters: ParametersObject = {
+        const halfOfParameters: ParametersObject<{bar: string, x1: string, y1: string}> = {
             bar: { required: true },
             x1: { declarationType: DeclarationType.secret, uri: "http://thing1" },
             y1: { declarationType: DeclarationType.mapped, uri: "http://thing2", required: false },
@@ -393,6 +393,23 @@ describe("command registrations", () => {
     it("should create command handler with autoSubmit", async () => {
         const reg: CommandHandlerRegistration<{ foo: string, bar: string }> = {
             name: "test",
+            listener: async ci => { return; },
+            autoSubmit: true,
+        };
+        const maker = commandHandlerRegistrationToCommand(null, reg);
+        const instance = toFactory(maker)() as SelfDescribingHandleCommand;
+        const md = metadataFromInstance(instance) as CommandHandlerMetadata;
+        assert(md.auto_submit);
+        assert.strictEqual(md.name, "test");
+    });
+
+    it("should match parameters for command handler", async () => {
+        const reg: CommandHandlerRegistration<{ foo: string, bar: string }> = {
+            name: "test",
+            parameters: {
+                foo: {},
+                bar: {},
+            },
             listener: async ci => { return; },
             autoSubmit: true,
         };


### PR DESCRIPTION
Ensure that definitions must match parameter types, avoiding potential errors. Consider this registration:

```typescript
const reg: CommandHandlerRegistration<{ foo: string, bar: string }> = {
      name: "test",
      parameters: {
            foo: {},
            bar: {},
        },
            ...
};
```

This change ensures that the names of the properties of the `parameters` field matches the names of the type of the parameters.