### PR TITLE
If an autofix error includes some output, print it to the progress log

### DIFF
--- a/lib/api-helper/listener/executeAutofixes.ts
+++ b/lib/api-helper/listener/executeAutofixes.ts
@@ -62,12 +62,12 @@ export function executeAutofixes(registrations: AutofixRegistration[]): ExecuteG
             const push = goalEvent.push;
             const appliedAutofixes: AutofixRegistration[] = [];
             const editResult = await configuration.sdm.projectLoader.doWithProject<EditResult>({
-                    credentials,
-                    id,
-                    context,
-                    readOnly: false,
-                    cloneOptions: minimalClone(push),
-                },
+                credentials,
+                id,
+                context,
+                readOnly: false,
+                cloneOptions: minimalClone(push),
+            },
                 async project => {
                     if ((await project.gitStatus()).sha !== id.sha) {
                         return {
@@ -122,6 +122,12 @@ export function executeAutofixes(registrations: AutofixRegistration[]): ExecuteG
         } catch (err) {
             logger.warn("Autofixes failed with '%s':\n%s", err.message, err.stack);
             progressLog.write(sprintf("Autofixes failed with '%s'", err.message));
+            if (err.stdout) {
+                progressLog.write(err.stdout);
+            }
+            if (err.stderr) {
+                progressLog.write(err.stderr);
+            }
             return {
                 code: 1,
                 message: err.message,


### PR DESCRIPTION
This puts output to the log in the case that one of the git commands fails. Otherwise, that output is completely munched, and I can't tell why a commit failed.