### PR TITLE
Populate the SHA on projects when loading them.

### DIFF
--- a/lib/api-helper/project/cloningProjectLoader.ts
+++ b/lib/api-helper/project/cloningProjectLoader.ts
@@ -26,6 +26,10 @@ export const CloningProjectLoader: ProjectLoader = {
         // tslint:disable-next-line:deprecation
         const cloneOptions = coords.cloneOptions ? coords.cloneOptions : { depth: coords.depth };
         const p = await GitCommandGitProject.cloned(coords.credentials, coords.id, cloneOptions);
+        if (p.id.sha === "HEAD") {
+            const gs = await p.gitStatus();
+            p.id.sha = gs.sha;
+        }
         return action(p);
     },
 };


### PR DESCRIPTION
The trigger for this is because we should have the SHA available in code inspections.
It is possible this will change something elsewhere. It seems like this is
useful to have generally. If it does cause problems, we could move it to only
do this on code inspections.