### PR TITLE
Make goal launching more pluggable

### DIFF
--- a/lib/api/goal/support/GoalLauncher.ts
+++ b/lib/api/goal/support/GoalLauncher.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/api/goal/support/GoalLauncher.ts
+++ b/lib/api/goal/support/GoalLauncher.ts
@@ -14,16 +14,23 @@
  * limitations under the License.
  */
 
-import {
-    HandlerContext,
-    HandlerResult,
-} from "@atomist/automation-client";
-import { ProgressLog } from "../../../spi/log/ProgressLog";
-import { SdmGoalEvent } from "../SdmGoalEvent";
+import { ExecuteGoalResult } from "../ExecuteGoalResult";
+import { GoalInvocation } from "../GoalInvocation";
 
 /**
- * Launch a goal in an isolated environment (container or process) for fulfillment.
+ * Launch a goal in an environment (container or process) for fulfillment.
  */
-export type IsolatedGoalLauncher = (goal: SdmGoalEvent,
-                                    ctx: HandlerContext,
-                                    progressLog: ProgressLog) => Promise<HandlerResult>;
+export interface GoalLauncher {
+
+    /**
+     * Does this GoalLauncher support launching provided goals
+     * @param gi
+     */
+    supports(gi: GoalInvocation): Promise<boolean>;
+
+    /**
+     * Launch the provided goal
+     * @param gi
+     */
+    launch(gi: GoalInvocation): Promise<ExecuteGoalResult>;
+}

--- a/lib/api/machine/SoftwareDeliveryMachineOptions.ts
+++ b/lib/api/machine/SoftwareDeliveryMachineOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/api/machine/SoftwareDeliveryMachineOptions.ts
+++ b/lib/api/machine/SoftwareDeliveryMachineOptions.ts
@@ -27,12 +27,8 @@ import { ProgressLogFactory } from "../../spi/log/ProgressLog";
 import { ProjectLoader } from "../../spi/project/ProjectLoader";
 import { RepoRefResolver } from "../../spi/repo-ref/RepoRefResolver";
 import { AddressChannels } from "../context/addressChannels";
-import { IsolatedGoalLauncher } from "../goal/support/IsolatedGoalLauncher";
+import { GoalLauncher } from "../goal/support/GoalLauncher";
 import { RepoTargets } from "./RepoTargets";
-
-/**
- * Parameters for targeting transforms or inspections to repos
- */
 
 /**
  * Infrastructure options common to all SoftwareDeliveryMachines.
@@ -86,7 +82,7 @@ export interface SoftwareDeliveryMachineOptions {
     /**
      * Strategy for launching goals in different infrastructure
      */
-    goalLauncher?: IsolatedGoalLauncher;
+    goalLauncher?: GoalLauncher | GoalLauncher[];
 
     /**
      * AddressChannels for communicating with system administrator.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Atomist Software Delivery Machine API",
   "author": {
     "name": "Atomist",


### PR DESCRIPTION
This PR introduces an improved extension point for launching goals. Several `GaolLauncher` instances can be registered; the first which `supports` method returns `true` will `launch` the goal.

This is a change in public API, but I don't expect anybody to have implemented a custom `IsolatedGoalLauncher` at this point.