### PR TITLE
Improve startingPoint handling in generators

### DIFF
--- a/lib/api-helper/command/generator/generatorCommand.ts
+++ b/lib/api-helper/command/generator/generatorCommand.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/api-helper/command/generator/generatorCommand.ts
+++ b/lib/api-helper/command/generator/generatorCommand.ts
@@ -26,7 +26,8 @@ import {
     RemoteRepoRef,
     RepoCreationParameters,
     RepoRef,
-    SeedDrivenGeneratorParameters, Success,
+    SeedDrivenGeneratorParameters,
+    Success,
 } from "@atomist/automation-client";
 import { HandleCommand } from "@atomist/automation-client/lib/HandleCommand";
 import { RedirectResult } from "@atomist/automation-client/lib/HandlerResult";
@@ -59,7 +60,10 @@ import {
     slackSuccessMessage,
 } from "../../misc/slack/messages";
 import { CachingProjectLoader } from "../../project/CachingProjectLoader";
-import { CommandListenerExecutionInterruptError, toCommandListenerInvocation } from "../../machine/handlerRegistrations";
+import {
+    CommandListenerExecutionInterruptError,
+    toCommandListenerInvocation,
+} from "../../machine/handlerRegistrations";
 import { CommandRegistration } from "../../../api/registration/CommandRegistration";
 
 /**

--- a/lib/api-helper/command/generator/generatorCommand.ts
+++ b/lib/api-helper/command/generator/generatorCommand.ts
@@ -40,13 +40,24 @@ import { AnyProjectEditor } from "@atomist/automation-client/lib/operations/edit
 import { generate } from "@atomist/automation-client/lib/operations/generate/generatorUtils";
 import { isProject } from "@atomist/automation-client/lib/project/Project";
 import { toFactory } from "@atomist/automation-client/lib/util/constructionUtils";
-import { bold, codeBlock, url, } from "@atomist/slack-messages";
+import {
+    bold,
+    codeBlock,
+    url,
+} from "@atomist/slack-messages";
 import * as _ from "lodash";
 import { SoftwareDeliveryMachineOptions } from "../../../api/machine/SoftwareDeliveryMachineOptions";
 import { StartingPoint } from "../../../api/registration/GeneratorRegistration";
 import { projectLoaderRepoLoader } from "../../machine/projectLoaderRepoLoader";
-import { MachineOrMachineOptions, toMachineOptions, } from "../../machine/toMachineOptions";
-import { slackErrorMessage, slackInfoMessage, slackSuccessMessage, } from "../../misc/slack/messages";
+import {
+    MachineOrMachineOptions,
+    toMachineOptions,
+} from "../../machine/toMachineOptions";
+import {
+    slackErrorMessage,
+    slackInfoMessage,
+    slackSuccessMessage,
+} from "../../misc/slack/messages";
 import { CachingProjectLoader } from "../../project/CachingProjectLoader";
 import { toCommandListenerInvocation } from "../../machine/handlerRegistrations";
 import { CommandRegistration } from "../../../api/registration/CommandRegistration";

--- a/lib/api-helper/command/generator/generatorCommand.ts
+++ b/lib/api-helper/command/generator/generatorCommand.ts
@@ -245,10 +245,9 @@ async function computeStartingPoint<P extends SeedDrivenGeneratorParameters>(par
         // It's a function that takes the parameters and returns either a project or a RemoteRepoRef
         const rr: RemoteRepoRef | Project | Promise<Project> = (startingPoint as any)(pi);
         if (isProjectPromise(rr)) {
-            await rr.then(async (p: Project) =>
-                infoMessage(`Using dynamically chosen starting point project ${bold(`${p.id.owner}:${p.id.repo}`)}`, ctx),
-            );
-            return rr;
+            const p = await rr;
+            await infoMessage(`Using dynamically chosen starting point project ${bold(`${p.id.owner}:${p.id.repo}`)}`, ctx);
+            return p;
         }
         if (isProject(rr)) {
             await infoMessage(`Using dynamically chosen starting point project ${bold(`${rr.id.owner}:${rr.id.repo}`)}`, ctx);

--- a/lib/api-helper/machine/handlerRegistrations.ts
+++ b/lib/api-helper/machine/handlerRegistrations.ts
@@ -257,6 +257,7 @@ export function generatorRegistrationToCommand<P = any>(sdm: MachineOrMachineOpt
         e.fallbackTarget || GitHubRepoCreationParameters,
         e.startingPoint,
         e,
+        e,
     );
 }
 
@@ -310,10 +311,10 @@ function toOnCommand<PARAMS>(c: CommandHandlerRegistration<any>): (sdm: MachineO
     };
 }
 
-function toCommandListenerInvocation<P>(c: CommandRegistration<P>,
-                                        context: HandlerContext,
-                                        parameters: P,
-                                        sdm: SoftwareDeliveryMachineOptions): CommandListenerInvocation {
+export function toCommandListenerInvocation<P>(c: CommandRegistration<P>,
+                                               context: HandlerContext,
+                                               parameters: P,
+                                               sdm: SoftwareDeliveryMachineOptions): CommandListenerInvocation {
     // It may already be there
     let credentials = !!context ? (context as any as SdmContext).credentials : undefined;
     let ids: RemoteRepoRef[];

--- a/lib/api/registration/GeneratorRegistration.ts
+++ b/lib/api/registration/GeneratorRegistration.ts
@@ -24,13 +24,14 @@ import {
     SeedDrivenGeneratorParameters,
 } from "@atomist/automation-client";
 import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
+import { ParametersInvocation } from "../listener/ParametersInvocation";
 
 /**
  * Starting point before transformation. Normally the coordinates of a
  * seed project, but can also be an in memory project or a function that
  * computes a RemoteRepoRef or Project from the parameters.
  */
-export type StartingPoint<PARAMS> = Project | RemoteRepoRef | ((parameters: PARAMS) => (RemoteRepoRef | Project | Promise<Project>));
+export type StartingPoint<PARAMS> = Project | RemoteRepoRef | ((pi: PARAMS & ParametersInvocation<PARAMS>) => (RemoteRepoRef | Project | Promise<Project>));
 
 /**
  * Register a project creation operation


### PR DESCRIPTION
1. Enable a function startingPoint for a generator registration to access the command listener invocation.
2. Enable the use of parameter gathering continuations in a startingPoint function.

Backward compatible.