### PR TITLE
Print statuses for each inspection in the AutoInspect goal

### DIFF
--- a/lib/api-helper/listener/executeAutoInspects.ts
+++ b/lib/api-helper/listener/executeAutoInspects.ts
@@ -138,7 +138,7 @@ export function executeAutoInspects(options: AutoInspectOptions): ExecuteGoal {
  * @param reviewListeners
  */
 function applyCodeInspections(goalInvocation: GoalInvocation,
-    options: AutoInspectOptions): (project: GitProject) => Promise<ExecuteGoalResult> {
+                              options: AutoInspectOptions): (project: GitProject) => Promise<ExecuteGoalResult> {
     return async project => {
         const { addressChannels } = goalInvocation;
         const cri = await createPushImpactListenerInvocation(goalInvocation, project);
@@ -213,8 +213,8 @@ function describeComment(c: ReviewComment): string {
 }
 
 async function gatherResponsesFromReviewListeners(progressLog: ProgressLog, reviews: ProjectReview[],
-    reviewListeners: ReviewListenerRegistration[],
-    pli: PushListenerInvocation):
+                                                  reviewListeners: ReviewListenerRegistration[],
+                                                  pli: PushListenerInvocation):
     Promise<PushImpactResponse[]> {
     const review = consolidate(reviews, pli.id);
     logger.info("Consolidated review of %j has %s comments", pli.id, review.comments.length);
@@ -223,7 +223,7 @@ async function gatherResponsesFromReviewListeners(progressLog: ProgressLog, revi
 }
 
 function responseFromOneListener(progressLog: ProgressLog,
-    rli: ReviewListenerInvocation): (l: ReviewListenerRegistration) => Promise<PushImpactResponse> {
+                                 rli: ReviewListenerInvocation): (l: ReviewListenerRegistration) => Promise<PushImpactResponse> {
     return async l => {
         try {
             progressLog.write(`Running review listener ${l.name}...`);
@@ -246,7 +246,7 @@ ${codeBlock(err.message)}` : ""}`,
 }
 
 function createParametersInvocation(goalInvocation: GoalInvocation,
-    autoInspect: AutoInspectRegistration<any, any>): ParametersInvocation<any> {
+                                    autoInspect: AutoInspectRegistration<any, any>): ParametersInvocation<any> {
     return {
         addressChannels: goalInvocation.addressChannels,
         preferences: goalInvocation.preferences,
@@ -269,6 +269,6 @@ function consolidate(reviews: ProjectReview[], repoId: RepoRef): ProjectReview {
 }
 
 async function sendErrorsToSlack(errors: ReviewerError[],
-    addressChannels: AddressChannels): Promise<void> {
+                                 addressChannels: AddressChannels): Promise<void> {
     await Promise.all(errors.map(async e => addressChannels(formatReviewerError(e))));
 }

--- a/lib/api-helper/listener/executeAutoInspects.ts
+++ b/lib/api-helper/listener/executeAutoInspects.ts
@@ -138,7 +138,7 @@ export function executeAutoInspects(options: AutoInspectOptions): ExecuteGoal {
  * @param reviewListeners
  */
 function applyCodeInspections(goalInvocation: GoalInvocation,
-                              options: AutoInspectOptions): (project: GitProject) => Promise<ExecuteGoalResult> {
+    options: AutoInspectOptions): (project: GitProject) => Promise<ExecuteGoalResult> {
     return async project => {
         const { addressChannels } = goalInvocation;
         const cri = await createPushImpactListenerInvocation(goalInvocation, project);
@@ -199,7 +199,7 @@ function applyCodeInspections(goalInvocation: GoalInvocation,
 
 function describeProjectReview(inspectionName: string, pr: ProjectReview): string {
     const commentStrings = pr.comments.map(describeComment);
-    const allComments = commentStrings.length === 0 ? "" : "\n" + commentStrings.join("\n");
+    const allComments = commentStrings.length === 0 ? "" : ":\n" + commentStrings.join("\n");
     return `${pr.comments.length} comments on ${pr.repoId.owner}/${pr.repoId.repo} by ${inspectionName}` + allComments;
 }
 
@@ -209,12 +209,12 @@ function describeComment(c: ReviewComment): string {
         category += "/" + c.subcategory;
     }
     const location = c.sourceLocation ? `${c.sourceLocation.path}#${c.sourceLocation.lineFrom1}: ` : "";
-    return `    ${c.severity} ${category} ${location}${c.detail}`;
+    return `  - [${c.severity} ${category} ${location}${c.detail}]`;
 }
 
 async function gatherResponsesFromReviewListeners(progressLog: ProgressLog, reviews: ProjectReview[],
-                                                  reviewListeners: ReviewListenerRegistration[],
-                                                  pli: PushListenerInvocation):
+    reviewListeners: ReviewListenerRegistration[],
+    pli: PushListenerInvocation):
     Promise<PushImpactResponse[]> {
     const review = consolidate(reviews, pli.id);
     logger.info("Consolidated review of %j has %s comments", pli.id, review.comments.length);
@@ -223,7 +223,7 @@ async function gatherResponsesFromReviewListeners(progressLog: ProgressLog, revi
 }
 
 function responseFromOneListener(progressLog: ProgressLog,
-                                 rli: ReviewListenerInvocation): (l: ReviewListenerRegistration) => Promise<PushImpactResponse> {
+    rli: ReviewListenerInvocation): (l: ReviewListenerRegistration) => Promise<PushImpactResponse> {
     return async l => {
         try {
             progressLog.write(`Running review listener ${l.name}...`);
@@ -246,7 +246,7 @@ ${codeBlock(err.message)}` : ""}`,
 }
 
 function createParametersInvocation(goalInvocation: GoalInvocation,
-                                    autoInspect: AutoInspectRegistration<any, any>): ParametersInvocation<any> {
+    autoInspect: AutoInspectRegistration<any, any>): ParametersInvocation<any> {
     return {
         addressChannels: goalInvocation.addressChannels,
         preferences: goalInvocation.preferences,
@@ -269,6 +269,6 @@ function consolidate(reviews: ProjectReview[], repoId: RepoRef): ProjectReview {
 }
 
 async function sendErrorsToSlack(errors: ReviewerError[],
-                                 addressChannels: AddressChannels): Promise<void> {
+    addressChannels: AddressChannels): Promise<void> {
     await Promise.all(errors.map(async e => addressChannels(formatReviewerError(e))));
 }

--- a/lib/api-helper/listener/executeAutoInspects.ts
+++ b/lib/api-helper/listener/executeAutoInspects.ts
@@ -136,7 +136,7 @@ export function executeAutoInspects(options: AutoInspectOptions): ExecuteGoal {
  * @param reviewListeners
  */
 function applyCodeInspections(goalInvocation: GoalInvocation,
-    options: AutoInspectOptions): (project: GitProject) => Promise<ExecuteGoalResult> {
+                              options: AutoInspectOptions): (project: GitProject) => Promise<ExecuteGoalResult> {
     return async project => {
         const { addressChannels } = goalInvocation;
         const cri = await createPushImpactListenerInvocation(goalInvocation, project);
@@ -192,8 +192,8 @@ function applyCodeInspections(goalInvocation: GoalInvocation,
 }
 
 async function gatherResponsesFromReviewListeners(reviews: ProjectReview[],
-    reviewListeners: ReviewListenerRegistration[],
-    pli: PushListenerInvocation):
+                                                  reviewListeners: ReviewListenerRegistration[],
+                                                  pli: PushListenerInvocation):
     Promise<PushImpactResponse[]> {
     const review = consolidate(reviews, pli.id);
     logger.info("Consolidated review of %j has %s comments", pli.id, review.comments.length);
@@ -219,7 +219,7 @@ ${codeBlock(err.message)}` : ""}`,
 }
 
 function createParametersInvocation(goalInvocation: GoalInvocation,
-    autoInspect: AutoInspectRegistration<any, any>): ParametersInvocation<any> {
+                                    autoInspect: AutoInspectRegistration<any, any>): ParametersInvocation<any> {
     return {
         addressChannels: goalInvocation.addressChannels,
         preferences: goalInvocation.preferences,
@@ -242,6 +242,6 @@ function consolidate(reviews: ProjectReview[], repoId: RepoRef): ProjectReview {
 }
 
 async function sendErrorsToSlack(errors: ReviewerError[],
-    addressChannels: AddressChannels): Promise<void> {
+                                 addressChannels: AddressChannels): Promise<void> {
     await Promise.all(errors.map(async e => addressChannels(formatReviewerError(e))));
 }

--- a/lib/api/goal/common/AutoCodeInspection.ts
+++ b/lib/api/goal/common/AutoCodeInspection.ts
@@ -59,7 +59,7 @@ export class AutoCodeInspection
     extends FulfillableGoalWithRegistrationsAndListeners<AutoInspectRegistration<any, any>, ReviewListenerRegistration> {
 
     constructor(private readonly details: FulfillableGoalDetails & AutoCodeInspectionOptions = {},
-        ...dependsOn: Goal[]) {
+                ...dependsOn: Goal[]) {
         super({
             ...getGoalDefinitionFrom(details, DefaultGoalNameGenerator.generateName("code-inspection"), CodeInspectionDefinition),
         }, ...dependsOn);

--- a/lib/api/goal/common/AutoCodeInspection.ts
+++ b/lib/api/goal/common/AutoCodeInspection.ts
@@ -59,9 +59,9 @@ export class AutoCodeInspection
     extends FulfillableGoalWithRegistrationsAndListeners<AutoInspectRegistration<any, any>, ReviewListenerRegistration> {
 
     constructor(private readonly details: FulfillableGoalDetails & AutoCodeInspectionOptions = {},
-                ...dependsOn: Goal[]) {
+        ...dependsOn: Goal[]) {
         super({
-            ...getGoalDefinitionFrom(details, DefaultGoalNameGenerator.generateName("code-inspection"), CodeInspectionDefintion),
+            ...getGoalDefinitionFrom(details, DefaultGoalNameGenerator.generateName("code-inspection"), CodeInspectionDefinition),
         }, ...dependsOn);
 
         const optsToUse = {
@@ -82,7 +82,7 @@ export class AutoCodeInspection
     }
 }
 
-const CodeInspectionDefintion: GoalDefinition = {
+const CodeInspectionDefinition: GoalDefinition = {
     uniqueName: "code-inspection",
     displayName: "code inspection",
     environment: IndependentOfEnvironment,


### PR DESCRIPTION
The autoinspect goal logs had no useful info. Before:

<img width="750" alt="screen shot 2019-02-04 at 2 24 46 pm" src="https://user-images.githubusercontent.com/1149737/52241484-b478f500-2888-11e9-8812-666b70f92d9d.png">

after this PR:
<img width="1415" alt="screen shot 2019-02-04 at 2 24 31 pm" src="https://user-images.githubusercontent.com/1149737/52241501-be025d00-2888-11e9-9b6f-0913c31d0f9f.png">

(this is with an SDM from the spring-seed, and the GitHubIssue review listener fails because the repo is a fork. But now, I get to see what is happening in the log, and also see the review comments that it could not send to GitHub.