### PR TITLE
Add conditional command registration

### DIFF
--- a/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
+++ b/lib/api-helper/machine/AbstractSoftwareDeliveryMachine.ts
@@ -39,7 +39,6 @@ import {
     NoProgressReport,
     ReportProgress,
 } from "../../api/goal/progress/ReportProgress";
-import { GoalImplementationMapper } from "../../api/goal/support/GoalImplementationMapper";
 import { TriggeredListenerInvocation } from "../../api/listener/TriggeredListener";
 import { validateConfigurationValues } from "../../api/machine/ConfigurationValues";
 import { ExtensionPack } from "../../api/machine/ExtensionPack";
@@ -54,6 +53,7 @@ import { PushRules } from "../../api/mapping/support/PushRules";
 import { CodeInspectionRegistration } from "../../api/registration/CodeInspectionRegistration";
 import { CodeTransformRegistration } from "../../api/registration/CodeTransformRegistration";
 import { CommandHandlerRegistration } from "../../api/registration/CommandHandlerRegistration";
+import { CommandRegistration } from "../../api/registration/CommandRegistration";
 import { EventHandlerRegistration } from "../../api/registration/EventHandlerRegistration";
 import { GeneratorRegistration } from "../../api/registration/GeneratorRegistration";
 import {
@@ -159,22 +159,30 @@ export abstract class AbstractSoftwareDeliveryMachine<O extends SoftwareDelivery
     }
 
     public addCommand<P>(cmd: CommandHandlerRegistration<P>): this {
-        this.registrationManager.addCommand(cmd);
+        if (this.shouldRegister(cmd)) {
+            this.registrationManager.addCommand(cmd);
+        }
         return this;
     }
 
     public addGeneratorCommand<P = NoParameters>(gen: GeneratorRegistration<P>): this {
-        this.registrationManager.addGeneratorCommand(gen);
+        if (this.shouldRegister(gen)) {
+            this.registrationManager.addGeneratorCommand(gen);
+        }
         return this;
     }
 
-    public addCodeTransformCommand<P>(ed: CodeTransformRegistration<P>): this {
-        this.registrationManager.addCodeTransformCommand<P>(ed);
+    public addCodeTransformCommand<P>(ct: CodeTransformRegistration<P>): this {
+        if (this.shouldRegister(ct)) {
+            this.registrationManager.addCodeTransformCommand<P>(ct);
+        }
         return this;
     }
 
     public addCodeInspectionCommand<R, P>(cir: CodeInspectionRegistration<R, P>): this {
-        this.registrationManager.addCodeInspectionCommand<R, P>(cir);
+        if (this.shouldRegister(cir)) {
+            this.registrationManager.addCodeInspectionCommand<R, P>(cir);
+        }
         return this;
     }
 
@@ -317,6 +325,12 @@ export abstract class AbstractSoftwareDeliveryMachine<O extends SoftwareDelivery
 
         // Register the goal completion listener to update goal set state
         this.addGoalCompletionListener(GoalSetGoalCompletionListener);
+    }
+
+    private shouldRegister<P>(cm: CommandRegistration<P>): boolean {
+        return !!cm.registerWhen ?
+            cm.registerWhen(this.configuration) :
+            true;
     }
 
 }

--- a/lib/api/registration/CommandRegistration.ts
+++ b/lib/api/registration/CommandRegistration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/api/registration/CommandRegistration.ts
+++ b/lib/api/registration/CommandRegistration.ts
@@ -19,11 +19,11 @@ import {
     RepoFinder,
     RepoLoader,
 } from "@atomist/automation-client";
+import { SoftwareDeliveryMachineConfiguration } from "../machine/SoftwareDeliveryMachineOptions";
 import { ParametersDefinition } from "./ParametersDefinition";
 
 /**
- * Type for registering a project transform, which can make changes
- * to projects
+ * Common supertype for all command registrations.
  */
 export interface CommandRegistration<PARAMS> {
 
@@ -44,7 +44,15 @@ export interface CommandRegistration<PARAMS> {
      */
     parameters?: ParametersDefinition<PARAMS>;
 
+    /**
+     * Intent or list of intents. What you need to type to invoke the
+     * command, for example via the bot.
+     */
     intent?: string | string[];
+
+    /**
+     * Tags associated with this command. Useful in searching.
+     */
     tags?: string | string[];
 
     /**
@@ -55,5 +63,15 @@ export interface CommandRegistration<PARAMS> {
     repoFinder?: RepoFinder;
 
     repoLoader?: (p: PARAMS) => RepoLoader;
+
+    /**
+     * If provided, select when this command is registered.
+     * Enables conditional registration on SDM startup, based on
+     * configuration, environment variables etc.
+     * This method is invoked during SDM startup.
+     * @param {SoftwareDeliveryMachineConfiguration} sdmConfiguration
+     * @return {boolean}
+     */
+    registerWhen?: (sdmConfiguration: SoftwareDeliveryMachineConfiguration) => boolean;
 
 }


### PR DESCRIPTION
This enables command registrations to be suppressed based on environment variables or SDM configuration.

This enables experimental features to be tried within one codebase without automatic exposure to all users.