### PR TITLE
Allow transform presentation on autofix goal

### DIFF
--- a/lib/api-helper/listener/executeAutofixes.ts
+++ b/lib/api-helper/listener/executeAutofixes.ts
@@ -20,8 +20,13 @@ import {
     RemoteRepoRef,
     Success,
 } from "@atomist/automation-client";
+import {
+    isBranchCommit,
+    isPullRequest,
+} from "@atomist/automation-client/lib/operations/edit/editModes";
 import { EditResult } from "@atomist/automation-client/lib/operations/edit/projectEditor";
 import { combineEditResults } from "@atomist/automation-client/lib/operations/edit/projectEditorOps";
+import { codeLine } from "@atomist/slack-messages";
 import * as _ from "lodash";
 import { sprintf } from "sprintf-js";
 import { ExecuteGoalResult } from "../../api/goal/ExecuteGoalResult";
@@ -33,6 +38,7 @@ import { ReportProgress } from "../../api/goal/progress/ReportProgress";
 import { PushImpactListenerInvocation } from "../../api/listener/PushImpactListener";
 import { SoftwareDeliveryMachineConfiguration } from "../../api/machine/SoftwareDeliveryMachineOptions";
 import { AutofixRegistration } from "../../api/registration/AutofixRegistration";
+import { TransformPresentation } from "../../api/registration/CodeTransformRegistration";
 import { PushAwareParametersInvocation } from "../../api/registration/PushAwareParametersInvocation";
 import { ProgressLog } from "../../spi/log/ProgressLog";
 import { SdmGoalState } from "../../typings/types";
@@ -47,12 +53,21 @@ import { createPushImpactListenerInvocation } from "./createPushImpactListenerIn
 import { relevantCodeActions } from "./relevantCodeActions";
 
 /**
+ * Parameters that includes the current GoalInvocation
+ */
+export interface GoalInvocationParameters {
+    /** Current goal invocation the autofixes are running */
+    goalInvocation: GoalInvocation;
+}
+
+/**
  * Execute autofixes against this push
  * Throw an error on failure
  * @param {AutofixRegistration[]} registrations
  * @return ExecuteGoal
  */
-export function executeAutofixes(registrations: AutofixRegistration[]): ExecuteGoal {
+export function executeAutofixes(registrations: AutofixRegistration[],
+                                 transformPresentation?: TransformPresentation<GoalInvocationParameters>): ExecuteGoal {
     return async (goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> => {
         const { id, configuration, goalEvent, credentials, context, progressLog } = goalInvocation;
         progressLog.write(sprintf("Attempting to apply %d configured autofixes", registrations.length));
@@ -60,6 +75,7 @@ export function executeAutofixes(registrations: AutofixRegistration[]): ExecuteG
             if (registrations.length === 0) {
                 return Success;
             }
+
             const push = goalEvent.push;
             const appliedAutofixes: AutofixRegistration[] = [];
             const editResult = await configuration.sdm.projectLoader.doWithProject<EditResult>({
@@ -76,10 +92,28 @@ export function executeAutofixes(registrations: AutofixRegistration[]): ExecuteG
                             edited: false,
                             target: project,
                             description: "Autofixes not executing",
-                            phase: "new commits on branch",
+                            phase: "new commit on branch",
                         };
                     }
                     const cri: PushImpactListenerInvocation = await createPushImpactListenerInvocation(goalInvocation, project);
+
+                    let editMode;
+                    if (!!transformPresentation) {
+                        editMode = transformPresentation({
+                            ...cri,
+                            parameters: {
+                                goalInvocation,
+                            },
+                        } as any, project);
+                        if (isBranchCommit(editMode) || isPullRequest(editMode)) {
+                            if (await project.hasBranch(editMode.branch)) {
+                                await project.checkout(editMode.branch);
+                            } else {
+                                await project.createBranch(editMode.branch);
+                            }
+                        }
+                    }
+
                     const relevantAutofixes: AutofixRegistration[] =
                         filterImmediateAutofixes(await relevantCodeActions(registrations, cri), goalInvocation);
                     progressLog.write(sprintf("Applying %d relevant autofixes of %d to %s/%s: '%s' of configured '%s'",
@@ -104,6 +138,21 @@ export function executeAutofixes(registrations: AutofixRegistration[]): ExecuteG
                     }
                     if (cumulativeResult.edited) {
                         await cri.project.push();
+
+                        if (!!editMode && isPullRequest(editMode)) {
+                            const targetBranch = editMode.targetBranch || cri.project.branch || cri.project.id.branch;
+                            let body = `${editMode.body}
+
+Applied autofixes:
+${appliedAutofixes.map(af => ` * ${codeLine(af.name)}`).join("\n")}
+
+[atomist:generated] [atomist:autofix]`.trim();
+
+                            if (editMode.autoMerge) {
+                                body = `${body} ${editMode.autoMerge.mode} ${editMode.autoMerge.method ? editMode.autoMerge.method : ""}`.trim();
+                            }
+                            await cri.project.raisePullRequest(editMode.title, body, targetBranch);
+                        }
                     }
                     return cumulativeResult;
                 });

--- a/lib/api-helper/machine/handlerRegistrations.ts
+++ b/lib/api-helper/machine/handlerRegistrations.ts
@@ -263,7 +263,7 @@ export function generatorRegistrationToCommand<P = any>(sdm: MachineOrMachineOpt
         e.paramsMaker,
         e.fallbackTarget || GitHubRepoCreationParameters,
         e.startingPoint,
-        e,
+        e as any, // required because we redefine the afterAction
         e,
     );
 }

--- a/lib/api/listener/CommandListener.ts
+++ b/lib/api/listener/CommandListener.ts
@@ -23,7 +23,7 @@ import { SdmListener } from "./Listener";
 import { ParametersInvocation } from "./ParametersInvocation";
 
 /**
- * Context for a commmand
+ * Context for a command
  */
 export interface CommandListenerInvocation<PARAMS = NoParameters> extends ParametersInvocation<PARAMS> {
 

--- a/lib/api/registration/CodeTransformRegistration.ts
+++ b/lib/api/registration/CodeTransformRegistration.ts
@@ -19,10 +19,16 @@ import {
     NoParameters,
     Project,
 } from "@atomist/automation-client";
-import { CommandListenerInvocation } from "../listener/CommandListener";
 import { TransformResult } from "./CodeTransform";
 import { ProjectOperationRegistration } from "./ProjectOperationRegistration";
 import { ProjectsOperationRegistration } from "./ProjectsOperationRegistration";
+import { PushAwareParametersInvocation } from "./PushAwareParametersInvocation";
+
+/**
+ * Signature to create an EditMode out of a PushAwareParametersInvocation and Project.
+ */
+export type TransformPresentation<PARAMS> =
+    (papi: PushAwareParametersInvocation<PARAMS>, p: Project) => EditMode;
 
 /**
  * Type for registering a project transform, which can make changes
@@ -38,19 +44,13 @@ export interface CodeTransformRegistration<PARAMS = NoParameters>
      * choose based on the invocation of this command and the code itself.
      *
      * This defaults to a pull request with branch name derived from the transform name.
-     * @param {CommandListenerInvocation<PARAMS>} ci
-     * @param {p: Project} p
-     * @return {EditMode}
      */
-    transformPresentation?: (ci: CommandListenerInvocation<PARAMS>, p: Project) => EditMode;
+    transformPresentation?: TransformPresentation<PARAMS>;
 
     /**
      * React to results from running transform across one or more projects
-     * @param results
-     * @param ci context
-     * @return {Promise<void>}
      */
-    onTransformResults?(results: TransformResult[], ci: CommandListenerInvocation<PARAMS>): Promise<void>;
+    onTransformResults?(results: TransformResult[], ci: PushAwareParametersInvocation<PARAMS>): Promise<void>;
 
 }
 

--- a/lib/api/registration/GeneratorRegistration.ts
+++ b/lib/api/registration/GeneratorRegistration.ts
@@ -35,6 +35,12 @@ export type StartingPoint<PARAMS> =
     Project | RemoteRepoRef | ((pi: PARAMS & ParametersInvocation<PARAMS>) => (RemoteRepoRef | Project | Promise<Project>));
 
 /**
+ * Action that executes after the project has been generated and pushed
+ * to the remote repository.
+ */
+export type ProjectAction<PARAMS> = (p: Project, pi: PARAMS & ParametersInvocation<PARAMS>) => Promise<void>;
+
+/**
  * Register a project creation operation
  */
 export interface GeneratorRegistration<PARAMS = NoParameters>
@@ -57,4 +63,11 @@ export interface GeneratorRegistration<PARAMS = NoParameters>
      * e.g. to target a different source control system.
      */
     fallbackTarget?: Maker<RepoCreationParameters>;
+
+    /**
+     * Hooks that get executed after a successful project generation.
+     * Note: these hooks fire after the project has been generated and
+     * pushed to the remote repository.
+     */
+    afterAction?: ProjectAction<PARAMS> | Array<ProjectAction<PARAMS>>;
 }


### PR DESCRIPTION
Also adds capabilities to run `ProjectAction` as `afterActions` on generators.

fixes #687, fixes #714 