### PR TITLE
Show autofix location in commit message

### DIFF
--- a/lib/api-helper/listener/executeAutofixes.ts
+++ b/lib/api-helper/listener/executeAutofixes.ts
@@ -66,8 +66,8 @@ export interface GoalInvocationParameters {
  * @return ExecuteGoal
  */
 export function executeAutofixes(registrations: AutofixRegistration[],
-                                 transformPresentation?: TransformPresentation<GoalInvocationParameters>,
-                                 extractAuthor: ExtractAuthor = NoOpExtractAuthor): ExecuteGoal {
+    transformPresentation?: TransformPresentation<GoalInvocationParameters>,
+    extractAuthor: ExtractAuthor = NoOpExtractAuthor): ExecuteGoal {
     return async (goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> => {
         const { id, configuration, goalEvent, credentials, context, progressLog } = goalInvocation;
         progressLog.write("Evaluating to %d configured autofixes", registrations.length);
@@ -80,12 +80,12 @@ export function executeAutofixes(registrations: AutofixRegistration[],
             const appliedAutofixes: AutofixRegistration[] = [];
             let editMode;
             const editResult = await configuration.sdm.projectLoader.doWithProject<EditResult>({
-                    credentials,
-                    id,
-                    context,
-                    readOnly: false,
-                    cloneOptions: minimalClone(push),
-                },
+                credentials,
+                id,
+                context,
+                readOnly: false,
+                cloneOptions: minimalClone(push),
+            },
                 async project => {
                     if ((await project.gitStatus()).sha !== id.sha) {
                         return {
@@ -207,9 +207,9 @@ function detailMessage(appliedAutofixes: AutofixRegistration[]): string {
 }
 
 async function runOne(gi: GoalInvocation,
-                      cri: PushImpactListenerInvocation,
-                      autofix: AutofixRegistration,
-                      extractAuthor: ExtractAuthor): Promise<EditResult> {
+    cri: PushImpactListenerInvocation,
+    autofix: AutofixRegistration,
+    extractAuthor: ExtractAuthor): Promise<EditResult> {
     const { progressLog, configuration } = gi;
     const project = cri.project;
     progressLog.write("About to transform %s with autofix '%s'", (project.id as RemoteRepoRef).url, autofix.name);
@@ -275,7 +275,7 @@ async function runOne(gi: GoalInvocation,
  * @returns {AutofixRegistration[]}
  */
 export function filterImmediateAutofixes(autofixes: AutofixRegistration[],
-                                         gi: GoalInvocation): AutofixRegistration[] {
+    gi: GoalInvocation): AutofixRegistration[] {
     return autofixes.filter(
         af => !(gi.goalEvent.push.commits || [])
             .some(c => c.message === generateCommitMessageForAutofix(af)));
@@ -288,7 +288,8 @@ export function filterImmediateAutofixes(autofixes: AutofixRegistration[],
  */
 export function generateCommitMessageForAutofix(autofix: AutofixRegistration): string {
     const name = autofix.name.toLowerCase().replace(/ /g, "_");
-    return `Autofix: ${autofix.name}\n\n[atomist:generated] [atomist:autofix=${name}]`;
+    const linkToSource = autofix.registrationSourceLocation ? `\n\nThis autofix is defined here: ${autofix.registrationSourceLocation.url}` : "";
+    return `Autofix: ${autofix.name}\n\n[atomist:generated] [atomist:autofix=${name}]${linkToSource}`;
 }
 
 export const AutofixProgressTests: ProgressTest[] = [{

--- a/lib/api-helper/listener/executeAutofixes.ts
+++ b/lib/api-helper/listener/executeAutofixes.ts
@@ -66,8 +66,8 @@ export interface GoalInvocationParameters {
  * @return ExecuteGoal
  */
 export function executeAutofixes(registrations: AutofixRegistration[],
-    transformPresentation?: TransformPresentation<GoalInvocationParameters>,
-    extractAuthor: ExtractAuthor = NoOpExtractAuthor): ExecuteGoal {
+                                 transformPresentation?: TransformPresentation<GoalInvocationParameters>,
+                                 extractAuthor: ExtractAuthor = NoOpExtractAuthor): ExecuteGoal {
     return async (goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> => {
         const { id, configuration, goalEvent, credentials, context, progressLog } = goalInvocation;
         progressLog.write("Evaluating to %d configured autofixes", registrations.length);
@@ -207,9 +207,9 @@ function detailMessage(appliedAutofixes: AutofixRegistration[]): string {
 }
 
 async function runOne(gi: GoalInvocation,
-    cri: PushImpactListenerInvocation,
-    autofix: AutofixRegistration,
-    extractAuthor: ExtractAuthor): Promise<EditResult> {
+                      cri: PushImpactListenerInvocation,
+                      autofix: AutofixRegistration,
+                      extractAuthor: ExtractAuthor): Promise<EditResult> {
     const { progressLog, configuration } = gi;
     const project = cri.project;
     progressLog.write("About to transform %s with autofix '%s'", (project.id as RemoteRepoRef).url, autofix.name);
@@ -275,7 +275,7 @@ async function runOne(gi: GoalInvocation,
  * @returns {AutofixRegistration[]}
  */
 export function filterImmediateAutofixes(autofixes: AutofixRegistration[],
-    gi: GoalInvocation): AutofixRegistration[] {
+                                         gi: GoalInvocation): AutofixRegistration[] {
     return autofixes.filter(
         af => !(gi.goalEvent.push.commits || [])
             .some(c => c.message === generateCommitMessageForAutofix(af)));

--- a/lib/api/registration/AutofixRegistration.ts
+++ b/lib/api/registration/AutofixRegistration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/api/registration/AutofixRegistration.ts
+++ b/lib/api/registration/AutofixRegistration.ts
@@ -17,6 +17,7 @@
 import { NoParameters } from "@atomist/automation-client";
 import { CodeTransformOrTransforms } from "./CodeTransform";
 import { PushSelector } from "./PushRegistration";
+import { RegistrationSourceLocation } from "./RegistrationSourceLocation";
 
 export interface AutofixRegistrationOptions {
 
@@ -30,6 +31,8 @@ export interface AutofixRegistrationOptions {
 export interface AutofixRegistration<P = NoParameters> extends PushSelector {
 
     transform: CodeTransformOrTransforms<P>;
+
+    registrationSourceLocation?: RegistrationSourceLocation;
 
     options?: AutofixRegistrationOptions;
 

--- a/lib/api/registration/RegistrationSourceLocation.ts
+++ b/lib/api/registration/RegistrationSourceLocation.ts
@@ -17,9 +17,9 @@
 import * as path from "path";
 import * as trace from "stack-trace";
 /**
- * Where is this registration located in the code? 
+ * Where is this registration located in the code?
  * Populate this with guessSourceLocation()
- * 
+ *
  * This lets an autofix commit message show where the autofix was registered,
  * giving developers the information they need to change it.
  */
@@ -49,7 +49,7 @@ export function guessSourceLocation(): RegistrationSourceLocation | undefined {
 }
 
 interface GuessedLocationWithinProject {
-    relativePath: string, lineNumber: number
+    relativePath: string; lineNumber: number;
 }
 function guessLocationWithinProject(): GuessedLocationWithinProject {
     let stack: trace.StackFrame[];
@@ -66,12 +66,11 @@ function guessLocationWithinProject(): GuessedLocationWithinProject {
     const relativePath = registration.getFileName().replace(appRoot, "");
     return {
         relativePath,
-        lineNumber: registration.getLineNumber()
+        lineNumber: registration.getLineNumber(),
     };
 }
-import * as appRootPath from "app-root-path";
 
-interface GuessedProjectLocation { repoUrl: string, sha?: string }
+interface GuessedProjectLocation { repoUrl: string; sha?: string; }
 function guessProjectLocation(): GuessedProjectLocation {
 
     try {
@@ -80,11 +79,10 @@ function guessProjectLocation(): GuessedProjectLocation {
 
         return {
             repoUrl: remoteUrlToHttp(gitInfo.repository),
-            sha: gitInfo.sha
-        }
+            sha: gitInfo.sha,
+        };
     } catch (gitInfoErr) {
 
-        console.log(gitInfoErr);
         try {
             const packageJson: { repository: string | { url: string } } =
                 require(process.cwd() + path.sep + "package.json");
@@ -94,15 +92,14 @@ function guessProjectLocation(): GuessedProjectLocation {
             }
             if (typeof packageJson.repository === "string") {
                 return {
-                    repoUrl: packageJson.repository
-                }
+                    repoUrl: packageJson.repository,
+                };
             }
             return {
-                repoUrl: packageJson.repository.url
-            }
+                repoUrl: packageJson.repository.url,
+            };
 
         } catch (packageJsonErr) {
-            console.log(packageJsonErr);
             return undefined;
         }
     }
@@ -116,7 +113,7 @@ function guessUrl(projectLocation: GuessedProjectLocation,
     }
     const likelyUrl =
         projectLocation.repoUrl.replace(/\/$/, "")
-            .replace(/.git$/, "")
+            .replace(/.git$/, "");
 
     const descendIntoCommit = "blob/" + (projectLocation.sha || "master");
 

--- a/lib/api/registration/RegistrationSourceLocation.ts
+++ b/lib/api/registration/RegistrationSourceLocation.ts
@@ -107,7 +107,7 @@ function guessProjectLocation(): GuessedProjectLocation {
 }
 
 function guessUrl(projectLocation: GuessedProjectLocation,
-    fileLocation: GuessedLocationWithinProject): string | undefined {
+                  fileLocation: GuessedLocationWithinProject): string | undefined {
     if (!projectLocation) {
         return undefined;
     }

--- a/lib/api/registration/RegistrationSourceLocation.ts
+++ b/lib/api/registration/RegistrationSourceLocation.ts
@@ -1,0 +1,121 @@
+
+import * as path from "path";
+import * as trace from "stack-trace";
+/**
+ * Where is this registration located in the code? 
+ * Populate this with guessSourceLocation()
+ * 
+ * This lets an autofix commit message show where the autofix was registered,
+ * giving developers the information they need to change it.
+ */
+export interface RegistrationSourceLocation {
+    url: string;
+}
+
+/**
+ * Use within declaration of an AutofixRegistration:
+ * {
+ * ...
+ * registrationSourceLocation: guessSourceLocation()
+ * }
+ */
+export function guessSourceLocation(): RegistrationSourceLocation | undefined {
+    try {
+
+        const fileLocation = guessLocationWithinProject();
+        const projectLocation = guessProjectLocation();
+
+        return {
+            url: guessUrl(projectLocation, fileLocation),
+        };
+    } catch (err) {
+        return undefined;
+    }
+}
+
+interface GuessedLocationWithinProject {
+    relativePath: string, lineNumber: number
+}
+function guessLocationWithinProject(): GuessedLocationWithinProject {
+    let stack: trace.StackFrame[];
+    try {
+        // Just throw an error so that we can capture the stack
+        throw new Error();
+    } catch (err) {
+        stack = trace.parse(err);
+    }
+    // 0 = guessLocationWithinProject, 1 = guessSourceLocation, 2 = the caller, where it's registered
+    const registration = stack[2];
+
+    const appRoot = process.cwd();
+    const relativePath = registration.getFileName().replace(appRoot, "");
+    return {
+        relativePath,
+        lineNumber: registration.getLineNumber()
+    };
+}
+import * as appRootPath from "app-root-path";
+
+interface GuessedProjectLocation { repoUrl: string, sha?: string }
+function guessProjectLocation(): GuessedProjectLocation {
+
+    try {
+        const gitInfo: { sha: string, repository: string } =
+            require(process.cwd() + path.sep + "git-info.json");
+
+        return {
+            repoUrl: remoteUrlToHttp(gitInfo.repository),
+            sha: gitInfo.sha
+        }
+    } catch (gitInfoErr) {
+
+        console.log(gitInfoErr);
+        try {
+            const packageJson: { repository: string | { url: string } } =
+                require(process.cwd() + path.sep + "package.json");
+
+            if (!packageJson.repository) {
+                return undefined;
+            }
+            if (typeof packageJson.repository === "string") {
+                return {
+                    repoUrl: packageJson.repository
+                }
+            }
+            return {
+                repoUrl: packageJson.repository.url
+            }
+
+        } catch (packageJsonErr) {
+            console.log(packageJsonErr);
+            return undefined;
+        }
+    }
+
+}
+
+function guessUrl(projectLocation: GuessedProjectLocation,
+    fileLocation: GuessedLocationWithinProject): string | undefined {
+    if (!projectLocation) {
+        return undefined;
+    }
+    const likelyUrl =
+        projectLocation.repoUrl.replace(/\/$/, "")
+            .replace(/.git$/, "")
+
+    const descendIntoCommit = "blob/" + (projectLocation.sha || "master");
+
+    if (!fileLocation) {
+        return likelyUrl + "/" + descendIntoCommit;
+    }
+    const filePortion = fileLocation.relativePath.replace(/^\//, "") + "#L" + fileLocation.lineNumber;
+
+    return likelyUrl + "/" + descendIntoCommit + "/" + filePortion;
+}
+
+function remoteUrlToHttp(remoteUrl: string): string {
+    if (remoteUrl.startsWith("http")) {
+        return remoteUrl;
+    }
+    return remoteUrl.replace(/git@(.*):/, "https://$1/");
+}

--- a/lib/api/registration/RegistrationSourceLocation.ts
+++ b/lib/api/registration/RegistrationSourceLocation.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import * as path from "path";
 import * as trace from "stack-trace";

--- a/test/api/registration/registrationSourceLocation.test.ts
+++ b/test/api/registration/registrationSourceLocation.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/api/registration/registrationSourceLocation.test.ts
+++ b/test/api/registration/registrationSourceLocation.test.ts
@@ -25,7 +25,7 @@ describe("guessSourceLocation", () => {
         assert(result.url.startsWith("https://github.com/atomist/sdm/blob/"),
             "where is the repo part of the link? <" + result.url + ">");
         // this is dependent on location of this file, and line in this file
-        assert(result.url.endsWith("test/api/registration/registrationSourceLocation.test.ts#22"),
+        assert(result.url.endsWith("test/api/registration/registrationSourceLocation.test.ts#L22"),
             "where is the file part of the link? " + result.url);
         assert(!result.url.includes("/Users"), "nooo, the local path is in it: <" + result.url + ">")
     });

--- a/test/api/registration/registrationSourceLocation.test.ts
+++ b/test/api/registration/registrationSourceLocation.test.ts
@@ -27,6 +27,6 @@ describe("guessSourceLocation", () => {
         // this is dependent on location of this file, and line in this file
         assert(result.url.endsWith("test/api/registration/registrationSourceLocation.test.ts#L22"),
             "where is the file part of the link? " + result.url);
-        assert(!result.url.includes("/Users"), "nooo, the local path is in it: <" + result.url + ">")
+        assert(!result.url.includes("/Users"), "nooo, the local path is in it: <" + result.url + ">");
     });
 });

--- a/test/api/registration/registrationSourceLocation.test.ts
+++ b/test/api/registration/registrationSourceLocation.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "assert";
+import { guessSourceLocation } from "../../../lib/api/registration/RegistrationSourceLocation";
+
+describe("guessSourceLocation", () => {
+    it("can guess this source location", async () => {
+        const result = guessSourceLocation();
+        assert(!!result, "No result returned");
+        assert(!!result.url, "No url returned");
+        assert(result.url.startsWith("https://github.com/atomist/sdm/blob/"),
+            "where is the repo part of the link? <" + result.url + ">");
+        // this is dependent on location of this file, and line in this file
+        assert(result.url.endsWith("test/api/registration/registrationSourceLocation.test.ts#22"),
+            "where is the file part of the link? " + result.url);
+        assert(!result.url.includes("/Users"), "nooo, the local path is in it: <" + result.url + ">")
+    });
+});


### PR DESCRIPTION
This gives people the option to include the location of the autofix registration in the registration itself. This lets the autofix include that in the commit message, like this:

```
 Autofix: TypeScript header

[atomist:generated] [atomist:autofix=typescript_header]

This autofix is defined here: https://github.com/atomist/atomist-sdm/blob/1ec8ca6bbb8df23f1a7a8230b57750fb0e1f87a9/lib/autofix/addAtomistHeader.ts#L47
```

(that link isn't perfect because the line number reflects local changes)

This will let developers find the autofix in order to change it.

This yak motivated by: I need to change the AddHeader autofix to not delete typedoc comments. It was hard to find that, I only found it because I knew where it would likely be. The name of the autofix in [autofix:${name}] is not searchable, as it's a modification of the name passed in.