### PR TITLE
Apply policy for TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9992,9 +9992,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.5.2"
+    "typescript": "^3.5.3"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Apply policy `typescript-version::typescript-version`:

**New TypeScript Version Policy**
Policy version for TypeScript is `^3.5.3`.
Project *atomist/sdm/master* is currently using version `^3.5.2`.

_TypeScript Version_
```TypeScript version (^3.5.3)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=65546ea5b01bb62f7b74c5d027cb8128f7cda8d5ae207501c0666411a403612d]</code>
</details>