### PR TITLE
Correct interface for spawnCodeTransform

### DIFF
--- a/lib/api-helper/code/autofix/spawnAutofix.ts
+++ b/lib/api-helper/code/autofix/spawnAutofix.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SpawnLogCommand } from "../../../api-helper/misc/child_process";
+import { SpawnLogInvocation } from "../../../api-helper/misc/child_process";
 import { PushTest } from "../../../api/mapping/PushTest";
 import {
     AutofixRegistration,
@@ -28,8 +28,8 @@ import { spawnCodeTransform } from "../../command/transform/spawnCodeTransform";
 export function spawnAutofix(name: string,
                              pushTest: PushTest,
                              options: AutofixRegistrationOptions,
-                             command1: SpawnLogCommand,
-                             ...additionalCommands: SpawnLogCommand[]): AutofixRegistration {
+                             command1: SpawnLogInvocation,
+                             ...additionalCommands: SpawnLogInvocation[]): AutofixRegistration {
     return {
         name,
         transform: spawnCodeTransform([command1, ...additionalCommands]),

--- a/lib/api-helper/command/transform/spawnCodeTransform.ts
+++ b/lib/api-helper/command/transform/spawnCodeTransform.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,19 @@ import {
     GitProject,
     GitStatus,
     logger,
+    NoParameters,
 } from "@atomist/automation-client";
 import {
     CodeTransform,
     TransformResult,
 } from "../../../api/registration/CodeTransform";
+import { PushAwareParametersInvocation } from "../../../api/registration/PushAwareParametersInvocation";
 import { ProgressLog } from "../../../spi/log/ProgressLog";
 import { LoggingProgressLog } from "../../log/LoggingProgressLog";
 import {
     spawnLog,
     SpawnLogCommand,
+    SpawnLogInvocation,
     SpawnLogOptions,
     SpawnLogResult,
 } from "../../misc/child_process";
@@ -66,13 +69,13 @@ async function spawnToTransform(p: GitProject, r: MinSpawnLogResult): Promise<Tr
  * @param log where to log output from commands
  * @return result of commands, success or the first failure
  */
-export function spawnCodeTransform(commands: SpawnLogCommand[], log: ProgressLog = new LoggingProgressLog("spawnCodeTransform")): CodeTransform {
-    return async (p: GitProject) => {
-        log.stripAnsi = true;
+export function spawnCodeTransform(commands: SpawnLogInvocation[], log?: ProgressLog): CodeTransform {
+    return async (p: GitProject, papi: PushAwareParametersInvocation<NoParameters>) => {
         const defaultOptions: SpawnLogOptions = {
             cwd: p.baseDir,
-            log,
+            log: log || papi.progressLog || new LoggingProgressLog("spawnCodeTransform"),
         };
+        defaultOptions.log.stripAnsi = true;
         let commandResult: MinSpawnLogResult;
         for (const cmd of commands) {
             try {

--- a/lib/api-helper/misc/child_process.ts
+++ b/lib/api-helper/misc/child_process.ts
@@ -101,12 +101,26 @@ export interface SpawnLogCommand {
 }
 
 /**
+ * Interface similar to [[SpawnLogCommand]] but making the log
+ * property optional since that can typically be obtained other ways
+ * when commands are invoked from within goals.
+ */
+export interface SpawnLogInvocation {
+    /** Executable able to be run by cross-spawn. */
+    command: string;
+    /** Arguments to command */
+    args?: string[];
+    /** Options to customize how command is run. */
+    options?: Partial<SpawnLogOptions>;
+}
+
+/**
  * Result returned by spawnAndLog after running a child process.  It
  * is compatible with handler results.  To support both HandlerResult
  * and SpawnPromiseReturns, the value of code and status are
  * identical.
  */
-export interface SpawnLogResult extends HandlerResult, SpawnPromiseReturns { }
+export type SpawnLogResult = HandlerResult & SpawnPromiseReturns;
 
 /**
  * Spawn a process, logging its standard output and standard error,

--- a/test/api-helper/code/autofix/spawnAutofix.test.ts
+++ b/test/api-helper/code/autofix/spawnAutofix.test.ts
@@ -37,7 +37,7 @@ describe("spawnAutofix", () => {
             { command: "node", args: ["-e", "process.exit(0);"] });
         assert(a.name === "test0");
         assert(a.pushTest.name === "ppt4");
-        const r = await (a.transform as CodeTransform)(p, undefined) as TransformResult;
+        const r = await (a.transform as CodeTransform)(p, {} as any) as TransformResult;
         assert(r);
         assert(r.target);
         assert(r.success === true);
@@ -55,7 +55,7 @@ describe("spawnAutofix", () => {
             { command: "node", args: ["-e", "process.exit(0);"] });
         assert(a.name === "test1");
         assert(a.pushTest.name === "ppt3");
-        const r = await (a.transform as CodeTransform)(p, undefined) as TransformResult;
+        const r = await (a.transform as CodeTransform)(p, {} as any) as TransformResult;
         assert(r);
         assert(r.target);
         assert(r.success === true);
@@ -76,7 +76,7 @@ describe("spawnAutofix", () => {
         );
         assert(a.name === "test2");
         assert(a.pushTest.name === "ppt2");
-        const r = await (a.transform as CodeTransform)(p, undefined) as TransformResult;
+        const r = await (a.transform as CodeTransform)(p, {} as any) as TransformResult;
         assert(r);
         assert(r.target);
         assert(r.success === true);
@@ -94,7 +94,7 @@ describe("spawnAutofix", () => {
             { command: "node", args: ["-e", "process.exit(1);"] });
         assert(a.name === "test3");
         assert(a.pushTest.name === "ppt1");
-        const r = await (a.transform as CodeTransform)(p, undefined) as TransformResult;
+        const r = await (a.transform as CodeTransform)(p, {} as any) as TransformResult;
         assert(r);
         assert(r.target);
         assert(r.success === false);
@@ -113,7 +113,7 @@ describe("spawnAutofix", () => {
             { command: "node", args: ["-e", "process.exit(4);"] });
         assert(a.name === "test4");
         assert(a.pushTest.name === "ppt0");
-        const r = await (a.transform as CodeTransform)(p, undefined) as TransformResult;
+        const r = await (a.transform as CodeTransform)(p, {} as any) as TransformResult;
         assert(r);
         assert(r.target);
         assert(r.success === false);
@@ -134,7 +134,7 @@ describe("spawnAutofix", () => {
         );
         assert(a.name === "test5");
         assert(a.pushTest.name === "ppt5");
-        const r = await (a.transform as CodeTransform)(p, undefined) as TransformResult;
+        const r = await (a.transform as CodeTransform)(p, {} as any) as TransformResult;
         assert(r);
         assert(r.target);
         assert(r.success === false);

--- a/test/api-helper/command/transform/spawnCodeTransform.test.ts
+++ b/test/api-helper/command/transform/spawnCodeTransform.test.ts
@@ -37,7 +37,7 @@ describe("spawnCodeTransform", () => {
             const t = spawnCodeTransform([
                 { command: "node", args: ["-e", "process.exit(0);"] },
             ]);
-            const r = await t(p, undefined) as TransformResult;
+            const r = await t(p, {} as any) as TransformResult;
             assert(r);
             assert(r.target);
             assert(r.success === true);
@@ -54,7 +54,7 @@ describe("spawnCodeTransform", () => {
             const t = spawnCodeTransform([
                 { command: "node", args: ["-e", "process.exit(0);"] },
             ]);
-            const r = await t(p, undefined) as TransformResult;
+            const r = await t(p, {} as any) as TransformResult;
             assert(r);
             assert(r.target);
             assert(r.success === true);
@@ -73,7 +73,7 @@ describe("spawnCodeTransform", () => {
                 { command: "node", args: ["-e", "process.exit(0);"] },
                 { command: "node", args: ["-e", "process.exit(0);"] },
             ]);
-            const r = await t(p, undefined) as TransformResult;
+            const r = await t(p, {} as any) as TransformResult;
             assert(r);
             assert(r.target);
             assert(r.success === true);
@@ -90,7 +90,7 @@ describe("spawnCodeTransform", () => {
             const t = spawnCodeTransform([
                 { command: "node", args: ["-e", "process.exit(1);"] },
             ]);
-            const r = await t(p, undefined) as TransformResult;
+            const r = await t(p, {} as any) as TransformResult;
             assert(r);
             assert(r.target);
             assert(r.success === false);
@@ -108,7 +108,7 @@ describe("spawnCodeTransform", () => {
             const t = spawnCodeTransform([
                 { command: "node", args: ["-e", "process.exit(4);"] },
             ]);
-            const r = await t(p, undefined) as TransformResult;
+            const r = await t(p, {} as any) as TransformResult;
             assert(r);
             assert(r.target);
             assert(r.success === false);
@@ -127,7 +127,7 @@ describe("spawnCodeTransform", () => {
                 { command: "node", args: ["-e", "process.exit(2);"] },
                 { command: "node", args: ["-e", "process.exit(0);"] },
             ]);
-            const r = await t(p, undefined) as TransformResult;
+            const r = await t(p, {} as any) as TransformResult;
             assert(r);
             assert(r.target);
             assert(r.success === false);

--- a/test/api/goal/common/Queue.test.ts
+++ b/test/api/goal/common/Queue.test.ts
@@ -48,7 +48,23 @@ describe("Queue", () => {
                 addGoalImplementation: async (implementationName: string,
                                               goal: Goal,
                                               goalExecutor: ExecuteGoal) => {
-                    const r = await goalExecutor({} as any);
+                    const c: any = {
+                        configuration: {
+                            name: "test",
+                        },
+                        context: {
+                            graphClient: {
+                                query: async () => { },
+                            },
+                        },
+                        goalEvent: {
+                            goalSetId: "x",
+                        },
+                        progressLog: {
+                            write: () => { },
+                        },
+                    };
+                    const r = await goalExecutor(c);
                     assert.strictEqual((r as any).state, SdmGoalState.in_process);
                 },
                 configuration: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
   "include": [
     "index.ts",
     "lib/**/*.ts",
-    "test/**/*.ts",
+    "test/**/*.ts"
   ],
   "exclude": [
     ".#*"


### PR DESCRIPTION
Add SpawnLogInvocation interface for calling spawnLog when a
ProgressLog is available.  Use this in spawnCodeTransform and use the
ProgressLog from the PushAwareParametersInvocation, if it is available
and one is not provided.

Clean up some tests.