### PR TITLE
Support RegExp Intents and retrieving parameters from them.

### DIFF
--- a/lib/api-helper/machine/handlerRegistrations.ts
+++ b/lib/api-helper/machine/handlerRegistrations.ts
@@ -463,6 +463,11 @@ export function toCommandListenerInvocation<P>(c: CommandRegistration<P>,
         }
     }
 
+    let matches: RegExpExecArray;
+    if (c.intent instanceof RegExp) {
+        matches = c.intent.exec((context as any).trigger.raw_message);
+    }
+
     const addressChannels = (msg, opts) => context.messageClient.respond(msg, opts);
     const promptFor = sdm.parameterPromptFactory ? sdm.parameterPromptFactory(context) : NoParameterPrompt;
     const preferences = sdm.preferenceStoreFactory ? sdm.preferenceStoreFactory(context) : NoPreferenceStore;
@@ -477,6 +482,7 @@ export function toCommandListenerInvocation<P>(c: CommandRegistration<P>,
         preferences,
         credentials,
         ids,
+        matches,
     };
 }
 

--- a/lib/api-helper/project/GitHubLazyProjectLoader.ts
+++ b/lib/api-helper/project/GitHubLazyProjectLoader.ts
@@ -16,7 +16,7 @@
 
 import {
     configurationValue,
-    DefaultHttpClientFactory,
+    defaultHttpClientFactory,
     GitHubRepoRef,
     GitProject,
     GitPushOptions,
@@ -379,7 +379,7 @@ export async function fileContent(token: string, rr: GitHubRepoRef, path: string
 async function filePromise(token: string, rr: GitHubRepoRef, path: string): Promise<HttpResponse<{ content: string }>> {
     const url = `${rr.scheme}${rr.apiBase}/repos/${rr.owner}/${rr.repo}/contents/${path}?ref=${rr.branch || "master"}`;
     logger.debug(`Requesting file from GitHub at '${url}'`);
-    const httpClient = configurationValue<HttpClientFactory>("http.client.factory", DefaultHttpClientFactory);
+    const httpClient = configurationValue<HttpClientFactory>("http.client.factory", defaultHttpClientFactory());
     return httpClient.create(url).exchange<{ content: string }>(url, {
         method: HttpMethod.Get,
         headers: {

--- a/lib/api-helper/project/fileCopy.ts
+++ b/lib/api-helper/project/fileCopy.ts
@@ -16,7 +16,7 @@
 
 import {
     configurationValue,
-    DefaultHttpClientFactory,
+    defaultHttpClientFactory,
     GitCommandGitProject,
     HttpMethod,
     logger,
@@ -33,7 +33,7 @@ import { CodeTransform } from "../../api/registration/CodeTransform";
  */
 export function copyFileFromUrl(url: string, path: string): CodeTransform {
     return async p => {
-        const http = configurationValue("http.client.factory", DefaultHttpClientFactory);
+        const http = configurationValue("http.client.factory", defaultHttpClientFactory());
         const response = await http.create(url).exchange<string>(url, { method: HttpMethod.Get });
         return p.addFile(path, response.body);
     };

--- a/lib/api/listener/CommandListener.ts
+++ b/lib/api/listener/CommandListener.ts
@@ -36,6 +36,11 @@ export interface CommandListenerInvocation<PARAMS = NoParameters> extends Parame
     ids?: RemoteRepoRef[];
 
     /**
+     * If the intent was a regular expression, the matches to the supplied intent are found here
+     */
+    matches?: RegExpExecArray;
+
+    /**
      * Prompt for additional parameters needed during execution of the command listener.
      *
      * Callers should wait for the returned Promise to resolve. It will resolve with the requested

--- a/lib/api/registration/CommandRegistration.ts
+++ b/lib/api/registration/CommandRegistration.ts
@@ -74,7 +74,7 @@ export interface CommandRegistration<PARAMS> {
      * Intent or list of intents. What you need to type to invoke the
      * command, for example via the bot.
      */
-    intent?: string | string[];
+    intent?: string | string[] | RegExp;
 
     /**
      * Tags associated with this command. Useful in searching.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@apollo/federation": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.11.0.tgz",
-      "integrity": "sha512-kzhnNl+G9G18R3tSkZ9kZKvDZq0Pq1X9WtbOLC+K2GfTvYLTIE5BG/21LuPZb9gO7W1/Xf1iquvMMGZdpILwRw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.11.2.tgz",
+      "integrity": "sha512-MSMBGOS9lAE0K4VmV/3mkd2qfLQTGt2OcsryRNbGMXr9gUVZDtM9quD5JUQoENkz9YFwcOY9jI+i/X5J+Fcw6A==",
       "dev": true,
       "requires": {
         "apollo-graphql": "^0.3.4",
@@ -17,9 +17,9 @@
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.1.tgz",
-      "integrity": "sha512-9NaTBPX+YYCsio6AqnLHlLiqYBszgTBul2qzG2+YNZ/1RQ2owhO/7xB5XJyQz76NGOefORaZt5idwvTJXpg/Sg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.2.tgz",
+      "integrity": "sha512-/kTaguTNSowXR/zWU4hjeL41yAdEbQO05f882c6cRIrVE7xIgJcBNEcYz2kzi94eaUbE2YY3SSxDJ6vPeV07OQ==",
       "dev": true,
       "requires": {
         "apollo-env": "^0.6.0"
@@ -61,9 +61,9 @@
       }
     },
     "@atomist/automation-client": {
-      "version": "2.0.0-master.20191206152722",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-2.0.0-master.20191206152722.tgz",
-      "integrity": "sha512-rEs++NcsZb9/7NY9IG6OXj+XY9ZF5qN1FpOSpM5mJTiWXz7kd6PqPysHu2jnzjoxJzv5Lffo914q4hM03FHl2A==",
+      "version": "2.0.0-ipcrm-sdm-793.20191223223841",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-2.0.0-ipcrm-sdm-793.20191223223841.tgz",
+      "integrity": "sha512-PBDNmwNg82wXW4rcwapdtgby2httZuE9a0b8+RoZ0UOaL/0ujIC01adf1Y1dS7G+dIT6z8gqWUFce4p1UoG3jA==",
       "dev": true,
       "requires": {
         "@atomist/microgrammar": "^1.2.1",
@@ -223,12 +223,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+      "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.6.3",
+        "@babel/types": "^7.7.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -243,19 +243,6 @@
         "@babel/helper-get-function-arity": "^7.7.4",
         "@babel/template": "^7.7.4",
         "@babel/types": "^7.7.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-          "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-get-function-arity": {
@@ -265,19 +252,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.7.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-          "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -287,19 +261,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.7.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-          "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/highlight": {
@@ -314,9 +275,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-      "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
       "dev": true
     },
     "@babel/template": {
@@ -328,19 +289,6 @@
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.4",
         "@babel/types": "^7.7.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-          "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/traverse": {
@@ -360,29 +308,6 @@
         "lodash": "^4.17.13"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.7.4",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-          "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -401,9 +326,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-      "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -679,14 +604,13 @@
       }
     },
     "@oclif/plugin-autocomplete": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.1.4.tgz",
-      "integrity": "sha512-ZyxJyL6jSt9Df68Smeu14xhZZwELE9IB5twhie1/56rt62nG6TJB4CZhaMqRk+33MDfU3JyWxNbIDMNMESlGqg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.1.5.tgz",
+      "integrity": "sha512-Afchpdd8FNfx9GaU/1D9IzyfiXvjfGybgzQ6G4GTFvPO0/hLdkXX3YyYq+SnxE6/bCrhg4pleiB+GuJACmmkEA==",
       "dev": true,
       "requires": {
         "@oclif/command": "^1.4.31",
         "@oclif/config": "^1.6.22",
-        "@types/fs-extra": "^5.0.2",
         "chalk": "^2.4.1",
         "cli-ux": "^4.4.0",
         "debug": "^3.1.0",
@@ -694,15 +618,6 @@
         "moment": "^2.22.1"
       },
       "dependencies": {
-        "@types/fs-extra": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-          "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
         "fs-extra": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -717,9 +632,9 @@
       }
     },
     "@oclif/plugin-help": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.1.tgz",
-      "integrity": "sha512-psEA3t41MSGBErLk6xCaAq2jKrRtx3Br+kHpd43vZeGEeZ7Gos4wgK0JAaHBbvhvUQskCHg8dzoqv4XEeTWeVQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.2.tgz",
+      "integrity": "sha512-Xh4o3TKEg5CsIpQx1XzzV0RYCShfksFuFF0CBodv5Eh1boAw06cBGv225LYdAX8lcSo9qklw/tuz2RsAsH0o9A==",
       "dev": true,
       "requires": {
         "@oclif/command": "^1.5.13",
@@ -779,9 +694,9 @@
       },
       "dependencies": {
         "cli-ux": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.3.3.tgz",
-          "integrity": "sha512-a16g+BTjASUH41s1pevai4P3JKwhx85wkOSm6sXWsk6KkdSmDeJ16pSCn2x3nqK7W8n35igOu2YiW+qFkqLRJg==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.4.1.tgz",
+          "integrity": "sha512-x5CJXJPKBrEo6o8Uy/Upajb9OWYMhTzOpRvKZyZ68kkHysiGd9phGP71WyHZfLUkhwdvpNUFkY2tsDr0ogyocg==",
           "dev": true,
           "requires": {
             "@oclif/command": "^1.5.1",
@@ -793,11 +708,13 @@
             "cardinal": "^2.1.1",
             "chalk": "^2.4.1",
             "clean-stack": "^2.0.0",
+            "cli-progress": "^3.4.0",
             "extract-stack": "^1.0.0",
             "fs-extra": "^7.0.1",
             "hyperlinker": "^1.0.0",
-            "indent-string": "^3.2.0",
+            "indent-string": "^4.0.0",
             "is-wsl": "^1.1.0",
+            "js-yaml": "^3.13.1",
             "lodash": "^4.17.11",
             "natural-orderby": "^2.0.1",
             "password-prompt": "^1.1.2",
@@ -829,6 +746,12 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -966,9 +889,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.35.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.0.tgz",
-      "integrity": "sha512-9ShFqYWo0CLoGYhA1FdtdykJuMzS/9H6vSbbQWDX4pWr4p9v+15MsH/wpd/3fIU+tSxylaNO48+PIHqOkBRx3w==",
+      "version": "16.35.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.2.tgz",
+      "integrity": "sha512-iijaNZpn9hBpUdh8YdXqNiWazmq4R1vCUsmxpBB0kCQ0asHZpCx+HNs22eiHuwYKRhO31ZSAGBJLi0c+3XHaKQ==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.2.0",
@@ -1038,9 +961,9 @@
       "dev": true
     },
     "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1101,9 +1024,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.0.tgz",
-      "integrity": "sha512-Xnub7w57uvcBqFdIGoRg1KhNOeEj0vB6ykUM7uFWyxvbdE89GFyqgmUcanAriMr4YOxNFZBAWkfcWIb4WBPt3g==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.1.tgz",
+      "integrity": "sha512-9e7jj549ZI+RxY21Cl0t8uBnWyb22HzILupyHZjYEVK//5TT/1bZodU+yUbLnPdoYViBBnNWbxp4zYjGV0zUGw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1614,28 +1537,28 @@
       }
     },
     "apollo": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.21.1.tgz",
-      "integrity": "sha512-bpQ+ToZS2HPBYzRCnv9hTbPmeuJZKDhOFy0EzxQhTPQPVqGkm1KZqFmFJZKdlydB6+XwIapdk0U1Q1utYKuXkQ==",
+      "version": "2.21.2",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.21.2.tgz",
+      "integrity": "sha512-RhiH3ffaIvobyDf3jXUmeIWvFCfxXwCYTU84hfRClRaL4bTaTd8T2/J5eVbcsd3AhPRbi4HJPxJBge4ewMepVw==",
       "dev": true,
       "requires": {
-        "@apollographql/apollo-tools": "^0.4.1",
+        "@apollographql/apollo-tools": "^0.4.2",
         "@oclif/command": "1.5.19",
         "@oclif/config": "1.13.3",
         "@oclif/errors": "1.2.2",
-        "@oclif/plugin-autocomplete": "0.1.4",
-        "@oclif/plugin-help": "2.2.1",
+        "@oclif/plugin-autocomplete": "0.1.5",
+        "@oclif/plugin-help": "2.2.2",
         "@oclif/plugin-not-found": "1.2.3",
         "@oclif/plugin-plugins": "1.7.8",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "^0.35.8",
-        "apollo-codegen-flow": "^0.33.33",
-        "apollo-codegen-scala": "^0.34.33",
-        "apollo-codegen-swift": "^0.35.13",
-        "apollo-codegen-typescript": "^0.35.8",
+        "apollo-codegen-core": "^0.35.9",
+        "apollo-codegen-flow": "^0.33.34",
+        "apollo-codegen-scala": "^0.34.34",
+        "apollo-codegen-swift": "^0.35.14",
+        "apollo-codegen-typescript": "^0.35.9",
         "apollo-env": "^0.6.0",
-        "apollo-graphql": "^0.3.5",
-        "apollo-language-server": "^1.17.1",
+        "apollo-graphql": "^0.3.6",
+        "apollo-language-server": "^1.17.2",
         "chalk": "2.4.2",
         "env-ci": "3.2.2",
         "gaze": "1.1.3",
@@ -1671,107 +1594,107 @@
       }
     },
     "apollo-cache": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
-      "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.4.tgz",
+      "integrity": "sha512-7X5aGbqaOWYG+SSkCzJNHTz2ZKDcyRwtmvW4mGVLRqdQs+HxfXS4dUS2CcwrAj449se6tZ6NLUMnjko4KMt3KA==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "^1.3.2",
-        "tslib": "^1.9.3"
+        "apollo-utilities": "^1.3.3",
+        "tslib": "^1.10.0"
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz",
-      "integrity": "sha512-S4B/zQNSuYc0M/1Wq8dJDTIO9yRgU0ZwDGnmlqxGGmFombOZb9mLjylewSfQKmjNpciZ7iUIBbJ0mHlPJTzdXg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.5.tgz",
+      "integrity": "sha512-koB76JUDJaycfejHmrXBbWIN9pRKM0Z9CJGQcBzIOtmte1JhEBSuzsOUu7NQgiXKYI4iGoMREcnaWffsosZynA==",
       "dev": true,
       "requires": {
-        "apollo-cache": "^1.3.2",
-        "apollo-utilities": "^1.3.2",
+        "apollo-cache": "^1.3.4",
+        "apollo-utilities": "^1.3.3",
         "optimism": "^0.10.0",
         "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
+        "tslib": "^1.10.0"
       }
     },
     "apollo-client": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.4.tgz",
-      "integrity": "sha512-oWOwEOxQ9neHHVZrQhHDbI6bIibp9SHgxaLRVPoGvOFy7OH5XUykZE7hBQAVxq99tQjBzgytaZffQkeWo1B4VQ==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.8.tgz",
+      "integrity": "sha512-0zvJtAcONiozpa5z5zgou83iEKkBaXhhSSXJebFHRXs100SecDojyUWKjwTtBPn9HbM6o5xrvC5mo9VQ5fgAjw==",
       "dev": true,
       "requires": {
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.2",
+        "apollo-cache": "1.3.4",
         "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.2",
+        "apollo-utilities": "1.3.3",
         "symbol-observable": "^1.0.2",
         "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
+        "tslib": "^1.10.0",
         "zen-observable": "^0.8.0"
       }
     },
     "apollo-codegen-core": {
-      "version": "0.35.8",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.35.8.tgz",
-      "integrity": "sha512-MWa7/3NWc2TkXTamD8Kypr+7P/QPGb7OOR+kpvZlffySZzjKvyCYI0odN6NhjmbKZFULNtZPg7OXX9SQX6YvoQ==",
+      "version": "0.35.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.35.9.tgz",
+      "integrity": "sha512-HBBv15ILH8Yiy65jtoZRmupT2pLY8dAGLbF4sZixmbPwI9D0wFq3Kt8zEaS2EHU9FBlPtR2fsx0/beUeftHqzA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.6.4",
+        "@babel/generator": "7.7.4",
         "@babel/parser": "^7.1.3",
-        "@babel/types": "7.6.3",
+        "@babel/types": "7.7.4",
         "apollo-env": "^0.6.0",
-        "apollo-language-server": "^1.17.1",
+        "apollo-language-server": "^1.17.2",
         "ast-types": "^0.13.0",
         "common-tags": "^1.5.1",
         "recast": "^0.18.0"
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.33.33",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.33.tgz",
-      "integrity": "sha512-vNUiSVTxXrPDrkge68SuaD1dBdlm2ZuxN5/GcICJP4VcVEtDCu/gXaWFkPAfyvQdCm9YdnzaR+ZQ3uF9MBCjhg==",
+      "version": "0.33.34",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.34.tgz",
+      "integrity": "sha512-UseAJlQfjTvLEpmRRP2JOVsuZQL/wyXSOXmK06iiZwednwWC54VbARS+fO2tfublB5q0i2d6GWXYBy9sIe6MQw==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.6.4",
-        "@babel/types": "7.6.3",
-        "apollo-codegen-core": "^0.35.8",
+        "@babel/generator": "7.7.4",
+        "@babel/types": "7.7.4",
+        "apollo-codegen-core": "^0.35.9",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.34.33",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.33.tgz",
-      "integrity": "sha512-h47IjNXdK0IWHcujPUynzdjkEvVZ1FoCDjAV1+yd3t27CwlEsND/q/ZH6DT5NwxZIWBJWnPNwBiiSOCt2/xFyw==",
+      "version": "0.34.34",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.34.tgz",
+      "integrity": "sha512-uYgGNmzZklynvB+d+grbsyGsXBMnfgM5EXlRjKJZN/Ss3Nz5l/bBtK7v+Ob3r/85P0rS0jreWL8Ddc6TLazRRQ==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "^0.35.8",
+        "apollo-codegen-core": "^0.35.9",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.35.13",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.35.13.tgz",
-      "integrity": "sha512-I29/lAcFeeeN/Dp6qp19kALh7aWXZXjEtPx1A6Ee7WjGonmIndixaQLL+glFLEXtACf/Eaq13pMl+2ZLG9098g==",
+      "version": "0.35.14",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.35.14.tgz",
+      "integrity": "sha512-dt6F4DAzq7Icy0BNg5QaRZLVBSJ8GXEW5cKbofKJjMNzIScXUS9Bp1u6+iWFajtsJCJjmTuTu863cn5SvrFSag==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "^0.35.8",
+        "apollo-codegen-core": "^0.35.9",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.35.8",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.35.8.tgz",
-      "integrity": "sha512-3dc4mle4o0tdXX/rSzKwMthlzHEV0RWMVMwbqSTy1pygyWsFI8UMkAFU4bC2KESILCA1k48LFjYQ7bKqx5RAFQ==",
+      "version": "0.35.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.35.9.tgz",
+      "integrity": "sha512-C2Q0U/htb4iIrGgkzGoepJGDcVf/FZ34b9IGtqPCWmrdQADMzgccI0h4rwXrjZGTQBr9+vHvlV/YFs+lriOR2g==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.6.4",
-        "@babel/types": "7.6.3",
-        "apollo-codegen-core": "^0.35.8",
+        "@babel/generator": "7.7.4",
+        "@babel/types": "7.7.4",
+        "apollo-codegen-core": "^0.35.9",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
@@ -1799,9 +1722,9 @@
       }
     },
     "apollo-graphql": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.5.tgz",
-      "integrity": "sha512-X2N/LREJSAkI0RhMEJ6d0kGjdJSI4SFyf6soLvLLTQn0Bhi/52hMLf8k4kO5t0SCKuWc1+Pw/tdCniK4Gc1IdA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.6.tgz",
+      "integrity": "sha512-PUBfW6t20U4CgPODTZB+3Z1Z+qhca8SNEHMPreiw+qEjXwEJF7SZItOIAs93HO0mA2K7eiZjCtZQZknaaQRZNA==",
       "dev": true,
       "requires": {
         "apollo-env": "^0.6.0",
@@ -1809,18 +1732,18 @@
       }
     },
     "apollo-language-server": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.17.1.tgz",
-      "integrity": "sha512-Ok3C+7W/P/VskQ99qxWMtWsr7g1opeEHfKtU+xJgoQN2qUJYwAEUMVNUFQ+HYRlVgyO1fZ4idcIGTcI+Lpa8Hw==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.17.2.tgz",
+      "integrity": "sha512-ml865Z9jzI5Y+48c5jsoSJCKz6ofOy45gCa+8SrJ/FyhOaIEEaXTfV4IgMIm/O4nz18zg4xPFu8dn4UCEr7O4w==",
       "dev": true,
       "requires": {
-        "@apollo/federation": "0.11.0",
-        "@apollographql/apollo-tools": "^0.4.1",
+        "@apollo/federation": "0.11.2",
+        "@apollographql/apollo-tools": "^0.4.2",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",
         "apollo-datasource": "^0.6.0",
         "apollo-env": "^0.6.0",
-        "apollo-graphql": "^0.3.5",
+        "apollo-graphql": "^0.3.6",
         "apollo-link": "^1.2.3",
         "apollo-link-context": "^1.0.9",
         "apollo-link-error": "^1.1.1",
@@ -1922,15 +1845,15 @@
       "dev": true
     },
     "apollo-utilities": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
-      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.3.tgz",
+      "integrity": "sha512-F14aX2R/fKNYMvhuP2t9GD9fggID7zp5I96MF5QeKYWDWTrkRdHRp4+SVfXUVN+cXOaB/IebfvRtzPf25CM0zw==",
       "dev": true,
       "requires": {
         "@wry/equality": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
         "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
+        "tslib": "^1.10.0"
       }
     },
     "app-root-path": {
@@ -2039,12 +1962,6 @@
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
-    },
     "asyncro": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/asyncro/-/asyncro-3.0.0.tgz",
@@ -2099,9 +2016,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
           "dev": true
         }
       }
@@ -2117,9 +2034,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -2404,19 +2321,19 @@
       }
     },
     "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
+        "readdirp": "~3.3.0"
       }
     },
     "clean-stack": {
@@ -2441,6 +2358,16 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-progress": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.4.0.tgz",
+      "integrity": "sha512-35zcc1FsbPfN2dVonxUQwEnqMnI5kDFx2G4qGFGWgIDYqZ6+3t4/GjX/Vk0tq6bNgI9dEFcWLJ6AaLN17NLBDA==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "string-width": "^2.1.1"
       }
     },
     "cli-truncate": {
@@ -2728,9 +2655,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.7.tgz",
-      "integrity": "sha512-qaPVGw30J1wQ0GR3GvoPqlGf9GZfKKF4kFC7kiHlcsPTqH3txrs9crCp3ZiMAXuSenhz89Jnl4GZs/67S5VOSg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
+      "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q==",
       "dev": true
     },
     "core-util-is": {
@@ -3668,9 +3595,9 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
@@ -3944,9 +3871,9 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
+      "integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -4239,9 +4166,9 @@
       "dev": true
     },
     "hot-shots": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.2.tgz",
-      "integrity": "sha512-CUWsmFxec3IvkyqKWCp81xwvzg41+FCQhqYWJeEpdocW1dmnbB89dM6sf9UuF2YYEmMH3MUWXYBtnBZHFMjXFg==",
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.5.tgz",
+      "integrity": "sha512-l+SeSK1eqmzDdWMMW5fBithdLDVoRaWBmm9iqW8eDt3Ic/SK6ALb7TFcLO6xy1f+mSDgSeaMrgrpgoGmBP1wXw==",
       "dev": true,
       "requires": {
         "unix-dgram": "2.0.x"
@@ -5825,9 +5752,9 @@
       }
     },
     "passport": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
-      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
       "dev": true,
       "requires": {
         "passport-strategy": "1.x.x",
@@ -6330,12 +6257,12 @@
       }
     },
     "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.0.7"
       }
     },
     "recast": {
@@ -7045,9 +6972,9 @@
       "dev": true
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "treeify": {
@@ -7606,13 +7533,10 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+      "dev": true
     },
     "x-xss-protection": {
       "version": "1.3.0",
@@ -7725,9 +7649,9 @@
       }
     },
     "yarn": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.21.0.tgz",
-      "integrity": "sha512-g9cvrdKXPZlz1eJYpKanQm3eywEmecudeyDkwiVWeswBrpHK3nJFBholkphHF9eNc8y/FNEhSQ8Et5ZAx4XyLw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.21.1.tgz",
+      "integrity": "sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==",
       "dev": true
     },
     "yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,9 +61,9 @@
       }
     },
     "@atomist/automation-client": {
-      "version": "2.0.0-ipcrm-sdm-793.20191223223841",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-2.0.0-ipcrm-sdm-793.20191223223841.tgz",
-      "integrity": "sha512-PBDNmwNg82wXW4rcwapdtgby2httZuE9a0b8+RoZ0UOaL/0ujIC01adf1Y1dS7G+dIT6z8gqWUFce4p1UoG3jA==",
+      "version": "2.0.0-master.20191224225156",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-2.0.0-master.20191224225156.tgz",
+      "integrity": "sha512-S6GNOycwYtk7/e70qXPImUYmFAJ/g2d9akM32uXT1C37vZG5IkUUx31tKwxABNRkpwhdXILmhbFpBF8UZ9oQOQ==",
       "dev": true,
       "requires": {
         "@atomist/microgrammar": "^1.2.1",
@@ -889,9 +889,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.35.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.2.tgz",
-      "integrity": "sha512-iijaNZpn9hBpUdh8YdXqNiWazmq4R1vCUsmxpBB0kCQ0asHZpCx+HNs22eiHuwYKRhO31ZSAGBJLi0c+3XHaKQ==",
+      "version": "16.36.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.36.0.tgz",
+      "integrity": "sha512-zoZj7Ya4vWBK4fjTwK2Cnmu7XBB1p9ygSvTk2TthN6DVJXM4hQZQoAiknWFLJWSTix4dnA3vuHtjPZbExYoCZA==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.2.0",
@@ -2655,9 +2655,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
-      "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
+      "integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ==",
       "dev": true
     },
     "core-util-is": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@atomist/slack-messages": "^1.1.1"
   },
   "devDependencies": {
-    "@atomist/automation-client": "2.0.0-master.20191206152722",
+    "@atomist/automation-client": "2.0.0-ipcrm-sdm-793.20191223223841",
     "@atomist/slack-messages": "^1.1.1",
     "@types/mocha": "^5.2.7",
     "@types/power-assert": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@atomist/slack-messages": "^1.1.1"
   },
   "devDependencies": {
-    "@atomist/automation-client": "2.0.0-ipcrm-sdm-793.20191223223841",
+    "@atomist/automation-client": "2.0.0-master.20191224225156",
     "@atomist/slack-messages": "^1.1.1",
     "@types/mocha": "^5.2.7",
     "@types/power-assert": "^1.5.0",


### PR DESCRIPTION
Closes #793 

This PR adds:
- Support to use RegExp as intents
- Attaches a new `matches` property to the `CommandListenerInvocation` that is a `RegExpExecArray` that contains the raw intent that was typed along with the matches to the intent regex (if it was supplied)
- ~~Depends on https://github.com/atomist/automation-client/pull/637~~
- ~~Will update package.json once 637 is merged~~