### PR TITLE
Kill timed out container goals

### DIFF
--- a/lib/api-helper/goal/sdmGoal.ts
+++ b/lib/api-helper/goal/sdmGoal.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import {
+    Configuration,
+    configurationValue,
+} from "@atomist/automation-client/lib/configuration";
 import { sprintf } from "sprintf-js";
 import { SdmGoalEvent } from "../../api/goal/SdmGoalEvent";
 import { SdmGoalKey } from "../../api/goal/SdmGoalMessage";
@@ -70,4 +74,11 @@ export function mergeGoalData(data: any, sdmGoal: SdmGoalEvent): any {
         ...goalData(sdmGoal),
         ...data,
     };
+}
+
+/**
+ * Return configured SDM goal timeout or default value, 10 minutes.
+ */
+export function sdmGoalTimeout(cfg?: Configuration): number {
+    return cfg?.sdm?.goal?.timeout || configurationValue<number>("sdm.goal.timeout", 1000 * 60 * 10);
 }

--- a/lib/api-helper/misc/child_process.ts
+++ b/lib/api-helper/misc/child_process.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Atomist, Inc.
+ * Copyright © 2020 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { configurationValue } from "@atomist/automation-client/lib/configuration";
 import { HandlerResult } from "@atomist/automation-client/lib/HandlerResult";
 import {
     execPromise,
@@ -31,6 +30,7 @@ import { logger } from "@atomist/automation-client/lib/util/logger";
 import { ChildProcess } from "child_process";
 import * as os from "os";
 import { ProgressLog } from "../../spi/log/ProgressLog";
+import { sdmGoalTimeout } from "../goal/sdmGoal";
 import { DelimitedWriteProgressLogDecorator } from "../log/DelimitedWriteProgressLogDecorator";
 
 /** Re-export child process objects from automation-client. */
@@ -143,7 +143,7 @@ export type SpawnLogResult = HandlerResult & SpawnPromiseReturns;
 export async function spawnLog(cmd: string, args: string[], opts: SpawnLogOptions): Promise<SpawnLogResult> {
     opts.errorFinder = (opts.errorFinder) ? opts.errorFinder : SuccessIsReturn0ErrorFinder;
     opts.log = new DelimitedWriteProgressLogDecorator(opts.log, "\n");
-    opts.timeout = (opts.timeout) ? opts.timeout : configurationValue<number>("sdm.goal.timeout", 10 * 60 * 1000);
+    opts.timeout = (opts.timeout) ? opts.timeout : sdmGoalTimeout();
 
     const spResult = await spawnPromise(cmd, args, opts);
     const slResult = {

--- a/lib/api-helper/misc/spawned.ts
+++ b/lib/api-helper/misc/spawned.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Atomist, Inc.
+ * Copyright © 2020 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { configurationValue } from "@atomist/automation-client/lib/configuration";
 import {
     ChildProcessResult,
     spawnAndWatch as clientSpawnAndWatch,
@@ -23,6 +22,7 @@ import {
 } from "@atomist/automation-client/lib/util/spawn";
 import { SpawnOptions } from "child_process";
 import { ProgressLog } from "../../spi/log/ProgressLog";
+import { sdmGoalTimeout } from "../goal/sdmGoal";
 import { DelimitedWriteProgressLogDecorator } from "../log/DelimitedWriteProgressLogDecorator";
 
 /* tslint:disable:deprecation */
@@ -44,7 +44,7 @@ export async function spawnAndWatch(spawnCommand: SpawnCommand,
 
     // Set the goal default timeout to 10mins
     if (!spOpts.timeout) {
-        spOpts.timeout = configurationValue<number>("sdm.goal.timeout", 1000 * 60 * 10);
+        spOpts.timeout = sdmGoalTimeout();
     }
 
     return clientSpawnAndWatch(spawnCommand, options, delimitedLog, spOpts);

--- a/lib/core/pack/k8s/container.ts
+++ b/lib/core/pack/k8s/container.ts
@@ -31,7 +31,10 @@ import {
     Merge,
 } from "ts-essentials";
 import { minimalClone } from "../../../api-helper/goal/minimalClone";
-import { goalData } from "../../../api-helper/goal/sdmGoal";
+import {
+    goalData,
+    sdmGoalTimeout,
+} from "../../../api-helper/goal/sdmGoal";
 import { RepoContext } from "../../../api/context/SdmContext";
 import { ExecuteGoalResult } from "../../../api/goal/ExecuteGoalResult";
 import {
@@ -251,7 +254,7 @@ export function k8sFulfillmentCallback(
             },
         ];
 
-        const copyContainer = _.cloneDeep(k8sScheduler.podSpec.spec.containers[0]);
+        const copyContainer = _.cloneDeep(k8sScheduler.podSpec.containers[0]);
         delete copyContainer.lifecycle;
         delete copyContainer.livenessProbe;
         delete copyContainer.readinessProbe;
@@ -510,7 +513,7 @@ export function executeK8sJob(): ExecuteGoal {
 
         const status = { code: 0, message: `Container '${containerName}' completed successfully` };
         try {
-            const timeout: number = configuration.sdm?.goal?.timeout || 10 * 60 * 1000;
+            const timeout = sdmGoalTimeout(configuration);
             const podStatus = await containerWatch(container, timeout);
             progressLog.write(`Container '${containerName}' exited: ${stringify(podStatus)}`);
         } catch (e) {
@@ -638,7 +641,7 @@ async function containerStarted(container: K8sContainer, attempts: number = 240)
 
     const sleepTime = 500; // ms
     for (let i = 0; i < attempts; i++) {
-        await sleep(500);
+        await sleep(sleepTime);
         let pod: k8s.V1Pod;
         try {
             pod = (await core.readNamespacedPod(container.pod, container.ns)).body;

--- a/lib/core/pack/k8s/sync/startup.ts
+++ b/lib/core/pack/k8s/sync/startup.ts
@@ -46,6 +46,9 @@ export const syncRepoStartupListener: StartupListener = async ctx => {
     if (!cluster.isMaster) {
         return;
     }
+    if (process.env.ATOMIST_ISOLATED_GOAL) {
+        return;
+    }
     await sdmRepoSync(sdm);
     const interval: number = _.get(sdm, "configuration.sdm.k8s.options.sync.intervalMinutes");
     if (interval && interval > 0) {

--- a/test/core/pack/k8s/container.test.ts
+++ b/test/core/pack/k8s/container.test.ts
@@ -51,7 +51,7 @@ import { containerTestImage } from "../../goal/container/util";
 
 /* tslint:disable:max-file-line-count */
 
-describe("goal/container/k8s", () => {
+describe("core/pack/k8s/container", () => {
 
     describe("k8sFulfillmentCallback", () => {
 
@@ -92,15 +92,13 @@ describe("goal/container/k8s", () => {
         } as any;
         const kgs = new KubernetesGoalScheduler();
         kgs.podSpec = {
-            spec: {
-                containers: [
-                    {
-                        image: "rod/argent:1945.6.14",
-                        name: "rod-argent",
-                    },
-                ],
-            },
-        } as any;
+            containers: [
+                {
+                    image: "rod/argent:1945.6.14",
+                    name: "rod-argent",
+                },
+            ],
+        };
         const rc: RepoContext = {
             configuration: {
                 apiKey: "AT0M15TAP1K3Y",
@@ -1045,34 +1043,32 @@ dGe21S9sMOqyEp9D8geeXkg3VAItxuXbLIBfKL45kwSvB6fEFtQnJEOrT4YXSRDY
         it("should add scheduler pod spec envs and volumeMounts to init container", async () => {
             const kgsx = new KubernetesGoalScheduler();
             kgsx.podSpec = {
-                spec: {
-                    containers: [
-                        {
-                            env: [
-                                {
-                                    name: "ATOMIST_CONFIG_PATH",
-                                    value: "/opt/atm/client.config.json",
-                                },
-                            ],
-                            image: "rod/argent:1945.6.14",
-                            livenessProbe: {
-                                httpGet: {
-                                    path: "/health",
-                                    port: "http",
-                                },
-                                initialDelaySeconds: 20,
+                containers: [
+                    {
+                        env: [
+                            {
+                                name: "ATOMIST_CONFIG_PATH",
+                                value: "/opt/atm/client.config.json",
                             },
-                            name: "rod-argent",
-                            volumeMounts: [
-                                {
-                                    mountPath: "/opt/atm",
-                                    name: "sdm-config",
-                                },
-                            ],
+                        ],
+                        image: "rod/argent:1945.6.14",
+                        livenessProbe: {
+                            httpGet: {
+                                path: "/health",
+                                port: "http" as unknown as object,
+                            },
+                            initialDelaySeconds: 20,
                         },
-                    ],
-                },
-            } as any;
+                        name: "rod-argent",
+                        volumeMounts: [
+                            {
+                                mountPath: "/opt/atm",
+                                name: "sdm-config",
+                            },
+                        ],
+                    },
+                ],
+            };
             const rcx: RepoContext = {
                 configuration: {
                     sdm: {


### PR DESCRIPTION
The first container in container goals will exit when the SDM goal
timeout is exceeded.  This does not kill the pod.  Add a check for
this case in the job cleanup logic.  Increase frequency of job
cleanup.  Centralize lookup of SDM goal timeout and job TTL.

Only record pod spec in KubernetesGoalScheduler.

Do not perform sync in isolated goals.

Towards #816 #815