### PR TITLE
K8s patch strategy and simplify KubernetesApplication

### DIFF
--- a/lib/core/pack/k8s/deploy/deploy.ts
+++ b/lib/core/pack/k8s/deploy/deploy.ts
@@ -72,7 +72,7 @@ export async function deployApplication(goalEvent: SdmGoalEvent, context: Handle
     const message = `Successfully deployed ${appId} to Kubernetes`;
     llog(message, logger.info, log);
     const description = `Deployed \`${dest}\``;
-    const externalUrls = await appExternalUrls(app, goalEvent);
+    const externalUrls = appExternalUrls(app);
     try {
         await syncApplication(app, resources);
     } catch (e) {

--- a/lib/core/pack/k8s/kubernetes/deployment.ts
+++ b/lib/core/pack/k8s/kubernetes/deployment.ts
@@ -57,7 +57,7 @@ export async function upsertDeployment(req: KubernetesResourceRequest): Promise<
     }
     logger.info(`Updating deployment ${slug} using '${logObject(spec)}'`);
     await logRetry(() => req.clients.apps.patchNamespacedDeployment(spec.metadata.name, spec.metadata.namespace, spec,
-        undefined, undefined, undefined, undefined, patchHeaders()), `patch deployment ${slug}`);
+        undefined, undefined, undefined, undefined, patchHeaders(req)), `patch deployment ${slug}`);
     return spec;
 }
 

--- a/lib/core/pack/k8s/kubernetes/deployment.ts
+++ b/lib/core/pack/k8s/kubernetes/deployment.ts
@@ -101,7 +101,6 @@ export async function deploymentTemplate(req: KubernetesApplication & Kubernetes
         kind,
         metadata,
         spec: {
-            replicas: (req.replicas || req.replicas === 0) ? req.replicas : 1,
             selector,
             strategy: {
                 type: "RollingUpdate",
@@ -149,9 +148,6 @@ export async function deploymentTemplate(req: KubernetesApplication & Kubernetes
         } as any;
         d.spec.template.spec.containers[0].readinessProbe = probe;
         d.spec.template.spec.containers[0].livenessProbe = probe;
-    }
-    if (req.imagePullSecret) {
-        d.spec.template.spec.imagePullSecrets = [{ name: req.imagePullSecret }];
     }
     if (req.roleSpec) {
         d.spec.template.spec.serviceAccountName = _.get(req, "serviceAccountSpec.metadata.name", req.name);

--- a/lib/core/pack/k8s/kubernetes/ingress.ts
+++ b/lib/core/pack/k8s/kubernetes/ingress.ts
@@ -105,9 +105,6 @@ export async function ingressTemplate(req: KubernetesApplication & KubernetesSdm
             paths: [httpPath],
         },
     } as any;
-    if (req.host) {
-        rule.host = req.host;
-    }
     const apiVersion = "extensions/v1beta1";
     const kind = "Ingress";
     const i: k8s.NetworkingV1beta1Ingress = {
@@ -118,16 +115,6 @@ export async function ingressTemplate(req: KubernetesApplication & KubernetesSdm
             rules: [rule],
         },
     };
-    if (req.tlsSecret) {
-        i.spec.tls = [
-            {
-                secretName: req.tlsSecret,
-            } as any,
-        ];
-        if (req.host) {
-            i.spec.tls[0].hosts = [req.host];
-        }
-    }
     if (req.ingressSpec) {
         _.merge(i, req.ingressSpec, { apiVersion, kind });
         i.metadata.namespace = req.ns;

--- a/lib/core/pack/k8s/kubernetes/ingress.ts
+++ b/lib/core/pack/k8s/kubernetes/ingress.ts
@@ -59,7 +59,7 @@ export async function upsertIngress(req: KubernetesResourceRequest): Promise<k8s
     }
     logger.info(`Ingress ${slug} exists, patching using '${logObject(spec)}'`);
     await logRetry(() => req.clients.ext.patchNamespacedIngress(spec.metadata.name, spec.metadata.namespace, spec,
-        undefined, undefined, undefined, undefined, patchHeaders()), `patch ingress ${slug}`);
+        undefined, undefined, undefined, undefined, patchHeaders(req)), `patch ingress ${slug}`);
     return spec;
 }
 

--- a/lib/core/pack/k8s/kubernetes/namespace.ts
+++ b/lib/core/pack/k8s/kubernetes/namespace.ts
@@ -49,7 +49,7 @@ export async function upsertNamespace(req: KubernetesResourceRequest): Promise<k
     logger.info(`Namespace ${slug} exists, patching using '${logObject(spec)}'`);
     try {
         await logRetry(() => req.clients.core.patchNamespace(spec.metadata.name, spec,
-            undefined, undefined, undefined, undefined, patchHeaders()), `patch namespace ${slug}`);
+            undefined, undefined, undefined, undefined, patchHeaders(req)), `patch namespace ${slug}`);
     } catch (e) {
         logger.warn(`Failed to patch existing namespace ${slug}, ignoring: ${k8sErrMsg(e)}`);
     }

--- a/lib/core/pack/k8s/kubernetes/patch.ts
+++ b/lib/core/pack/k8s/kubernetes/patch.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { KubernetesApplication } from "./request";
+
 /** Return type from [[patchHeaders]]. */
 export interface K8sHeaders {
     headers: {
@@ -29,10 +31,11 @@ export interface K8sHeaders {
  * https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
  * for details.
  */
-export function patchHeaders(): K8sHeaders {
+export function patchHeaders(app: Pick<KubernetesApplication, "patchStrategy">): K8sHeaders {
+    const contentType = (app?.patchStrategy) ? app.patchStrategy : "application/strategic-merge-patch+json";
     return {
         headers: {
-            "Content-Type": "application/strategic-merge-patch+json",
+            "Content-Type": contentType,
         },
     };
 }

--- a/lib/core/pack/k8s/kubernetes/request.ts
+++ b/lib/core/pack/k8s/kubernetes/request.ts
@@ -140,6 +140,15 @@ export interface KubernetesApplication {
      * also provided.
      */
     roleBindingSpec?: DeepPartial<k8s.V1RoleBinding> | DeepPartial<k8s.V1ClusterRoleBinding>;
+    /**
+     * Strategy to use when patching resources for this application.
+     * Supported values are "application/merge-patch+json" and
+     * "application/strategic-merge-patch+json".  The default is
+     * "application/strategic-merge-patch+json".  See
+     * https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
+     * for details.
+     */
+    patchStrategy?: "application/merge-patch+json" | "application/strategic-merge-patch+json";
 }
 
 /**

--- a/lib/core/pack/k8s/kubernetes/request.ts
+++ b/lib/core/pack/k8s/kubernetes/request.ts
@@ -50,18 +50,6 @@ export interface KubernetesApplication {
      */
     mode?: "full" | "sync";
     /**
-     * Name of image pull secret for container image, if not provided
-     * no image pull secret is provided in the pod spec.
-     * Prefer deploymentSpec.
-     */
-    imagePullSecret?: string;
-    /**
-     * Number of replicas in deployment.  May be overridden by
-     * deploymentSpec.
-     * Prefer deploymentSpec
-     */
-    replicas?: number;
-    /**
      * Port the service listens on, if not provided, no service
      * resource is created.
      */
@@ -72,24 +60,6 @@ export interface KubernetesApplication {
      * ("/") but do not end with one, unless the path is just "/".
      */
     path?: string;
-    /**
-     * Ingress rule hostname, if not provided none is used in the
-     * ingress rule, meaning it will apply to the wildcard host, and
-     * "localhost" is used when constructing the service endpoint URL.
-     * Prefer ingressSpec
-     */
-    host?: string;
-    /**
-     * Ingress protocol, "http" or "https".  If tslSecret is provided,
-     * the default is "https", otherwise "http".
-     * Prefer ingressSpec
-     */
-    protocol?: "http" | "https";
-    /**
-     * Name of TLS secret for host
-     * Prefer ingressSpec
-     */
-    tlsSecret?: string;
     /**
      * Partial deployment spec for this application that is overlaid
      * on top of the default deployment spec template.  It can be used

--- a/lib/core/pack/k8s/kubernetes/role.ts
+++ b/lib/core/pack/k8s/kubernetes/role.ts
@@ -50,7 +50,7 @@ export async function upsertRole(req: KubernetesResourceRequest): Promise<k8s.V1
         }
         logger.info(`Cluster role ${slug} exists, patching using '${logObject(spec)}'`);
         await logRetry(() => req.clients.rbac.patchClusterRole(spec.metadata.name, spec,
-            undefined, undefined, undefined, undefined, patchHeaders()), `patch cluster role ${slug}`);
+            undefined, undefined, undefined, undefined, patchHeaders(req)), `patch cluster role ${slug}`);
         return spec;
     } else {
         const spec = await roleTemplate(req);
@@ -64,7 +64,7 @@ export async function upsertRole(req: KubernetesResourceRequest): Promise<k8s.V1
         }
         logger.info(`Role ${slug} exists, patching using '${logObject(spec)}'`);
         await logRetry(() => req.clients.rbac.patchNamespacedRole(spec.metadata.name, spec.metadata.namespace, spec,
-            undefined, undefined, undefined, undefined, patchHeaders()), `patch role ${slug}`);
+            undefined, undefined, undefined, undefined, patchHeaders(req)), `patch role ${slug}`);
         return spec;
     }
 }

--- a/lib/core/pack/k8s/kubernetes/roleBinding.ts
+++ b/lib/core/pack/k8s/kubernetes/roleBinding.ts
@@ -51,7 +51,7 @@ export async function upsertRoleBinding(req: KubernetesResourceRequest): Promise
         }
         logger.info(`Cluster role binding ${slug} exists, patching using '${logObject(spec)}'`);
         await logRetry(() => req.clients.rbac.patchClusterRoleBinding(spec.metadata.name, spec,
-            undefined, undefined, undefined, undefined, patchHeaders()), `patch cluster role binding ${slug}`);
+            undefined, undefined, undefined, undefined, patchHeaders(req)), `patch cluster role binding ${slug}`);
         return spec;
     } else {
         const spec = await roleBindingTemplate(req);
@@ -66,7 +66,7 @@ export async function upsertRoleBinding(req: KubernetesResourceRequest): Promise
         }
         logger.info(`Role binding ${slug} exists, patching using '${logObject(spec)}'`);
         await logRetry(() => req.clients.rbac.patchNamespacedRoleBinding(spec.metadata.name, spec.metadata.namespace, spec,
-            undefined, undefined, undefined, undefined, patchHeaders()), `patch role binding ${slug}`);
+            undefined, undefined, undefined, undefined, patchHeaders(req)), `patch role binding ${slug}`);
         return spec;
     }
 }

--- a/lib/core/pack/k8s/kubernetes/secret.ts
+++ b/lib/core/pack/k8s/kubernetes/secret.ts
@@ -63,7 +63,7 @@ export async function upsertSecrets(req: KubernetesResourceRequest): Promise<k8s
         }
         logger.info(`Secret ${secretName} exists, patching using '${logObject(spec)}'`);
         await logRetry(() => req.clients.core.patchNamespacedSecret(secret.metadata.name, spec.metadata.namespace, spec,
-            undefined, undefined, undefined, undefined, patchHeaders()), `patch secret ${secretName} for ${slug}`);
+            undefined, undefined, undefined, undefined, patchHeaders(req)), `patch secret ${secretName} for ${slug}`);
         return spec;
     }));
     return ss;

--- a/lib/core/pack/k8s/kubernetes/service.ts
+++ b/lib/core/pack/k8s/kubernetes/service.ts
@@ -58,7 +58,7 @@ export async function upsertService(req: KubernetesResourceRequest): Promise<k8s
     }
     logger.info(`Service ${slug} exists, patching using '${logObject(spec)}'`);
     await logRetry(() => req.clients.core.patchNamespacedService(spec.metadata.name, spec.metadata.namespace, spec,
-        undefined, undefined, undefined, undefined, patchHeaders()), `patch service ${slug}`);
+        undefined, undefined, undefined, undefined, patchHeaders(req)), `patch service ${slug}`);
     return spec;
 }
 

--- a/lib/core/pack/k8s/kubernetes/serviceAccount.ts
+++ b/lib/core/pack/k8s/kubernetes/serviceAccount.ts
@@ -50,7 +50,7 @@ export async function upsertServiceAccount(req: KubernetesResourceRequest): Prom
     }
     logger.info(`Service account ${slug} exists, patching using '${logObject(spec)}'`);
     await logRetry(() => req.clients.core.patchNamespacedServiceAccount(spec.metadata.name, spec.metadata.namespace, spec,
-        undefined, undefined, undefined, undefined, patchHeaders()), `patch service account ${slug}`);
+        undefined, undefined, undefined, undefined, patchHeaders(req)), `patch service account ${slug}`);
     return spec;
 }
 

--- a/test/core/pack/k8s/kubernetes/deployment.test.ts
+++ b/test/core/pack/k8s/kubernetes/deployment.test.ts
@@ -16,20 +16,23 @@
 
 import * as assert from "power-assert";
 import { deploymentTemplate } from "../../../../../lib/core/pack/k8s/kubernetes/deployment";
+import {
+    KubernetesApplication,
+    KubernetesSdm,
+} from "../../../../../lib/core/pack/k8s/kubernetes/request";
 
 /* tslint:disable:max-file-line-count */
 
-describe("pack/k8s/kubernetes/deployment", () => {
+describe("core/pack/k8s/kubernetes/deployment", () => {
 
     describe("deploymentTemplate", () => {
 
         it("should create a deployment spec", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
                 image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
-                imagePullSecret: "comfort",
                 port: 5510,
                 sdmFulfiller: "EMI",
             };
@@ -41,7 +44,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
             assert(d.metadata.labels["app.kubernetes.io/name"] === r.name);
             assert(d.metadata.labels["app.kubernetes.io/part-of"] === r.name);
             assert(d.metadata.labels["atomist.com/workspaceId"] === r.workspaceId);
-            assert(d.spec.replicas === 1);
             assert(d.spec.selector.matchLabels["app.kubernetes.io/name"] === r.name);
             assert(d.spec.selector.matchLabels["atomist.com/workspaceId"] === r.workspaceId);
             assert(d.spec.template.metadata.annotations["atomist.com/k8vent"] ===
@@ -63,22 +65,19 @@ describe("pack/k8s/kubernetes/deployment", () => {
             assert(d.spec.template.spec.containers[0].livenessProbe.httpGet.path === "/");
             assert(d.spec.template.spec.containers[0].livenessProbe.httpGet.port === "http" as any);
             assert(d.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds === 30);
-            assert(d.spec.template.spec.imagePullSecrets[0].name === r.imagePullSecret);
         });
 
         it("should create a custom deployment spec", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
                 image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
-                imagePullSecret: "comfort",
                 port: 5510,
                 sdmFulfiller: "EMI",
                 deploymentSpec: {
                     spec: {
                         replicas: 2,
-                        restartPolicy: "Never",
                         revisionHistoryLimit: 5,
                         template: {
                             spec: {
@@ -86,11 +85,14 @@ describe("pack/k8s/kubernetes/deployment", () => {
                                     { imagePullPolicy: "Always" },
                                 ],
                                 dnsPolicy: "ClusterFirstWithHostNet",
+                                imagePullSecrets: [
+                                    { name: "comfort" },
+                                ],
+                                restartPolicy: "Never",
                             },
                         },
                     },
                 },
-                replicas: 12,
             };
             const d = await deploymentTemplate(r);
             const e = {
@@ -108,7 +110,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                 },
                 spec: {
                     replicas: 2,
-                    restartPolicy: "Never",
                     revisionHistoryLimit: 5,
                     selector: {
                         matchLabels: {
@@ -170,9 +171,10 @@ describe("pack/k8s/kubernetes/deployment", () => {
                             dnsPolicy: "ClusterFirstWithHostNet",
                             imagePullSecrets: [
                                 {
-                                    name: r.imagePullSecret,
+                                    name: "comfort",
                                 },
                             ],
+                            restartPolicy: "Never",
                         },
                     },
                     strategy: {
@@ -188,19 +190,17 @@ describe("pack/k8s/kubernetes/deployment", () => {
         });
 
         it("should fix API version and kind in provided spec", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
                 image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
-                imagePullSecret: "comfort",
                 port: 5510,
                 sdmFulfiller: "EMI",
                 deploymentSpec: {
                     apiVersion: "extensions/v1beta1",
                     kind: "Deploy",
                 },
-                replicas: 12,
             };
             const d = await deploymentTemplate(r);
             const e = {
@@ -217,7 +217,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                     },
                 },
                 spec: {
-                    replicas: 12,
                     selector: {
                         matchLabels: {
                             "app.kubernetes.io/name": r.name,
@@ -272,11 +271,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                                             containerPort: r.port,
                                         },
                                     ],
-                                },
-                            ],
-                            imagePullSecrets: [
-                                {
-                                    name: r.imagePullSecret,
                                 },
                             ],
                         },
@@ -294,12 +288,11 @@ describe("pack/k8s/kubernetes/deployment", () => {
         });
 
         it("should allow overriding name but not namespace", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
                 image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
-                imagePullSecret: "comfort",
                 port: 5510,
                 sdmFulfiller: "EMI",
                 deploymentSpec: {
@@ -308,7 +301,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                         namespace: "the-kick-inside",
                     },
                 },
-                replicas: 12,
             };
             const d = await deploymentTemplate(r);
             const e = {
@@ -325,7 +317,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                     },
                 },
                 spec: {
-                    replicas: 12,
                     selector: {
                         matchLabels: {
                             "app.kubernetes.io/name": r.name,
@@ -380,188 +371,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                                             containerPort: r.port,
                                         },
                                     ],
-                                },
-                            ],
-                            imagePullSecrets: [
-                                {
-                                    name: r.imagePullSecret,
-                                },
-                            ],
-                        },
-                    },
-                    strategy: {
-                        type: "RollingUpdate",
-                        rollingUpdate: {
-                            maxUnavailable: 0,
-                            maxSurge: 1,
-                        },
-                    },
-                },
-            };
-            assert.deepStrictEqual(d, e);
-        });
-
-        it("should create a deployment spec with zero replicas", async () => {
-            const r = {
-                workspaceId: "KAT3BU5H",
-                ns: "hounds-of-love",
-                name: "cloudbusting",
-                image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
-                imagePullSecret: "comfort",
-                port: 5510,
-                replicas: 0,
-                sdmFulfiller: "EMI",
-            };
-            const d = await deploymentTemplate(r);
-            const e = {
-                apiVersion: "apps/v1",
-                kind: "Deployment",
-                metadata: {
-                    name: r.name,
-                    namespace: r.ns,
-                    labels: {
-                        "app.kubernetes.io/managed-by": r.sdmFulfiller,
-                        "app.kubernetes.io/name": r.name,
-                        "app.kubernetes.io/part-of": r.name,
-                        "atomist.com/workspaceId": r.workspaceId,
-                    },
-                },
-                spec: {
-                    replicas: 0,
-                    selector: {
-                        matchLabels: {
-                            "app.kubernetes.io/name": r.name,
-                            "atomist.com/workspaceId": r.workspaceId,
-                        },
-                    },
-                    template: {
-                        metadata: {
-                            name: r.name,
-                            labels: {
-                                "app.kubernetes.io/managed-by": r.sdmFulfiller,
-                                "app.kubernetes.io/name": r.name,
-                                "app.kubernetes.io/part-of": r.name,
-                                "atomist.com/workspaceId": r.workspaceId,
-                            },
-                            annotations: {
-                                "atomist.com/k8vent": `{"webhooks":["https://webhook.atomist.com/atomist/kube/teams/${r.workspaceId}"]}`,
-                            },
-                        },
-                        spec: {
-                            containers: [
-                                {
-                                    name: r.name,
-                                    image: r.image,
-                                    resources: {
-                                        limits: {
-                                            cpu: "1000m",
-                                            memory: "384Mi",
-                                        },
-                                        requests: {
-                                            cpu: "100m",
-                                            memory: "320Mi",
-                                        },
-                                    },
-                                    readinessProbe: {
-                                        httpGet: {
-                                            path: "/",
-                                            port: "http",
-                                        },
-                                        initialDelaySeconds: 30,
-                                    },
-                                    livenessProbe: {
-                                        httpGet: {
-                                            path: "/",
-                                            port: "http",
-                                        },
-                                        initialDelaySeconds: 30,
-                                    },
-                                    ports: [
-                                        {
-                                            name: "http",
-                                            containerPort: r.port,
-                                        },
-                                    ],
-                                },
-                            ],
-                            imagePullSecrets: [
-                                {
-                                    name: r.imagePullSecret,
-                                },
-                            ],
-                        },
-                    },
-                    strategy: {
-                        type: "RollingUpdate",
-                        rollingUpdate: {
-                            maxUnavailable: 0,
-                            maxSurge: 1,
-                        },
-                    },
-                },
-            };
-            assert.deepStrictEqual(d, e);
-        });
-
-        it("should create a deployment spec with custom replicas", async () => {
-            const r = {
-                workspaceId: "KAT3BU5H",
-                ns: "hounds-of-love",
-                name: "cloudbusting",
-                image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
-                replicas: 12,
-                sdmFulfiller: "EMI",
-            };
-            const d = await deploymentTemplate(r);
-            const e = {
-                apiVersion: "apps/v1",
-                kind: "Deployment",
-                metadata: {
-                    name: r.name,
-                    namespace: r.ns,
-                    labels: {
-                        "app.kubernetes.io/managed-by": r.sdmFulfiller,
-                        "app.kubernetes.io/name": r.name,
-                        "app.kubernetes.io/part-of": r.name,
-                        "atomist.com/workspaceId": r.workspaceId,
-                    },
-                },
-                spec: {
-                    replicas: 12,
-                    selector: {
-                        matchLabels: {
-                            "app.kubernetes.io/name": r.name,
-                            "atomist.com/workspaceId": r.workspaceId,
-                        },
-                    },
-                    template: {
-                        metadata: {
-                            name: r.name,
-                            labels: {
-                                "app.kubernetes.io/managed-by": r.sdmFulfiller,
-                                "app.kubernetes.io/name": r.name,
-                                "app.kubernetes.io/part-of": r.name,
-                                "atomist.com/workspaceId": r.workspaceId,
-                            },
-                            annotations: {
-                                "atomist.com/k8vent": `{"webhooks":["https://webhook.atomist.com/atomist/kube/teams/${r.workspaceId}"]}`,
-                            },
-                        },
-                        spec: {
-                            containers: [
-                                {
-                                    name: r.name,
-                                    image: r.image,
-                                    resources: {
-                                        limits: {
-                                            cpu: "1000m",
-                                            memory: "384Mi",
-                                        },
-                                        requests: {
-                                            cpu: "100m",
-                                            memory: "320Mi",
-                                        },
-                                    },
                                 },
                             ],
                         },
@@ -579,7 +388,7 @@ describe("pack/k8s/kubernetes/deployment", () => {
         });
 
         it("should create a deployment spec with service account", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
@@ -602,7 +411,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                     },
                 },
                 spec: {
-                    replicas: 1,
                     selector: {
                         matchLabels: {
                             "app.kubernetes.io/name": r.name,
@@ -655,7 +463,7 @@ describe("pack/k8s/kubernetes/deployment", () => {
         });
 
         it("should create a deployment spec using service account name", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
@@ -691,7 +499,6 @@ describe("pack/k8s/kubernetes/deployment", () => {
                     },
                 },
                 spec: {
-                    replicas: 1,
                     selector: {
                         matchLabels: {
                             "app.kubernetes.io/name": r.name,

--- a/test/core/pack/k8s/kubernetes/ingress.test.ts
+++ b/test/core/pack/k8s/kubernetes/ingress.test.ts
@@ -19,14 +19,18 @@ import {
     ingressTemplate,
     upsertIngress,
 } from "../../../../../lib/core/pack/k8s/kubernetes/ingress";
-import { KubernetesResourceRequest } from "../../../../../lib/core/pack/k8s/kubernetes/request";
+import {
+    KubernetesApplication,
+    KubernetesResourceRequest,
+    KubernetesSdm,
+} from "../../../../../lib/core/pack/k8s/kubernetes/request";
 
-describe("pack/k8s/kubernetes/ingress", () => {
+describe("core/pack/k8s/kubernetes/ingress", () => {
 
     describe("ingressTemplate", () => {
 
         it("should create a wildcard ingress spec", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
@@ -43,10 +47,10 @@ describe("pack/k8s/kubernetes/ingress", () => {
                     name: "cloudbusting",
                     namespace: "hounds-of-love",
                     labels: {
-                        "app.kubernetes.io/managed-by": r.sdmFulfiller,
-                        "app.kubernetes.io/name": r.name,
-                        "app.kubernetes.io/part-of": r.name,
-                        "atomist.com/workspaceId": r.workspaceId,
+                        "app.kubernetes.io/managed-by": "EMI",
+                        "app.kubernetes.io/name": "cloudbusting",
+                        "app.kubernetes.io/part-of": "cloudbusting",
+                        "atomist.com/workspaceId": "KAT3BU5H",
                     },
                 },
                 spec: {
@@ -56,70 +60,13 @@ describe("pack/k8s/kubernetes/ingress", () => {
                                 paths: [
                                     {
                                         backend: {
-                                            serviceName: r.name,
+                                            serviceName: "cloudbusting",
                                             servicePort: "http",
                                         },
-                                        path: r.path,
+                                        path: "/bush/kate/hounds-of-love/cloudbusting",
                                     },
                                 ],
                             },
-                        },
-                    ],
-                },
-            };
-            assert.deepStrictEqual(i, e);
-        });
-
-        it("should create a host ingress spec", async () => {
-            const r = {
-                workspaceId: "KAT3BU5H",
-                ns: "hounds-of-love",
-                name: "cloudbusting",
-                image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
-                port: 5510,
-                path: "/bush/kate/hounds-of-love/cloudbusting",
-                host: "emi.com",
-                protocol: "https" as "https",
-                sdmFulfiller: "EMI",
-                tlsSecret: "emi-com",
-            };
-            const i = await ingressTemplate(r);
-            const e = {
-                apiVersion: "extensions/v1beta1",
-                kind: "Ingress",
-                metadata: {
-                    labels: {
-                        "app.kubernetes.io/managed-by": r.sdmFulfiller,
-                        "app.kubernetes.io/name": r.name,
-                        "app.kubernetes.io/part-of": r.name,
-                        "atomist.com/workspaceId": r.workspaceId,
-                    },
-                    name: "cloudbusting",
-                    namespace: "hounds-of-love",
-                },
-                spec: {
-                    rules: [
-                        {
-                            host: r.host,
-                            http: {
-                                paths: [
-                                    {
-                                        backend: {
-                                            serviceName: r.name,
-                                            servicePort: "http",
-                                        },
-                                        path: r.path,
-                                    },
-                                ],
-                            },
-                        },
-                    ],
-                    tls: [
-                        {
-                            hosts: [
-                                "emi.com",
-                            ],
-                            secretName: "emi-com",
                         },
                     ],
                 },
@@ -128,17 +75,14 @@ describe("pack/k8s/kubernetes/ingress", () => {
         });
 
         it("should merge in provided ingress spec", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
                 image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
                 port: 5510,
                 path: "/bush/kate/hounds-of-love/cloudbusting",
-                host: "emi.com",
-                protocol: "https" as "https",
                 sdmFulfiller: "EMI",
-                tlsSecret: "emi-com",
                 ingressSpec: {
                     metadata: {
                         annotations: {
@@ -148,6 +92,10 @@ describe("pack/k8s/kubernetes/ingress", () => {
                             "nginx.ingress.kubernetes.io/limit-rps": "25",
                             "nginx.ingress.kubernetes.io/rewrite-target": "/cb",
                         },
+                    },
+                    spec: {
+                        rules: [{ host: "emi.com" }],
+                        tls: [{ hosts: ["emi.com"], secretName: "emi-com" }],
                     },
                 } as any,
             };
@@ -164,10 +112,10 @@ describe("pack/k8s/kubernetes/ingress", () => {
                         "nginx.ingress.kubernetes.io/limit-rps": "25",
                     },
                     labels: {
-                        "app.kubernetes.io/managed-by": r.sdmFulfiller,
-                        "app.kubernetes.io/name": r.name,
-                        "app.kubernetes.io/part-of": r.name,
-                        "atomist.com/workspaceId": r.workspaceId,
+                        "app.kubernetes.io/managed-by": "EMI",
+                        "app.kubernetes.io/name": "cloudbusting",
+                        "app.kubernetes.io/part-of": "cloudbusting",
+                        "atomist.com/workspaceId": "KAT3BU5H",
                     },
                     name: "cloudbusting",
                     namespace: "hounds-of-love",
@@ -175,15 +123,15 @@ describe("pack/k8s/kubernetes/ingress", () => {
                 spec: {
                     rules: [
                         {
-                            host: r.host,
+                            host: "emi.com",
                             http: {
                                 paths: [
                                     {
                                         backend: {
-                                            serviceName: r.name,
+                                            serviceName: "cloudbusting",
                                             servicePort: "http",
                                         },
-                                        path: r.path,
+                                        path: "/bush/kate/hounds-of-love/cloudbusting",
                                     },
                                 ],
                             },
@@ -203,17 +151,14 @@ describe("pack/k8s/kubernetes/ingress", () => {
         });
 
         it("should correct API version and kind in provided spec", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
                 image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
                 port: 5510,
                 path: "/bush/kate/hounds-of-love/cloudbusting",
-                host: "emi.com",
-                protocol: "https" as "https",
                 sdmFulfiller: "EMI",
-                tlsSecret: "emi-com",
                 ingressSpec: {
                     apiVersion: "v1",
                     kind: "Egress",
@@ -236,7 +181,6 @@ describe("pack/k8s/kubernetes/ingress", () => {
                 spec: {
                     rules: [
                         {
-                            host: r.host,
                             http: {
                                 paths: [
                                     {
@@ -250,31 +194,20 @@ describe("pack/k8s/kubernetes/ingress", () => {
                             },
                         },
                     ],
-                    tls: [
-                        {
-                            hosts: [
-                                "emi.com",
-                            ],
-                            secretName: "emi-com",
-                        },
-                    ],
                 },
             };
             assert.deepStrictEqual(s, e);
         });
 
         it("should allow overriding name but not namespace", async () => {
-            const r = {
+            const r: KubernetesApplication & KubernetesSdm = {
                 workspaceId: "KAT3BU5H",
                 ns: "hounds-of-love",
                 name: "cloudbusting",
                 image: "gcr.io/kate-bush/hounds-of-love/cloudbusting:5.5.10",
                 port: 5510,
                 path: "/bush/kate/hounds-of-love/cloudbusting",
-                host: "emi.com",
-                protocol: "https" as "https",
                 sdmFulfiller: "EMI",
-                tlsSecret: "emi-com",
                 ingressSpec: {
                     metadata: {
                         name: "wuthering-heights",
@@ -299,7 +232,6 @@ describe("pack/k8s/kubernetes/ingress", () => {
                 spec: {
                     rules: [
                         {
-                            host: r.host,
                             http: {
                                 paths: [
                                     {
@@ -311,14 +243,6 @@ describe("pack/k8s/kubernetes/ingress", () => {
                                     },
                                 ],
                             },
-                        },
-                    ],
-                    tls: [
-                        {
-                            hosts: [
-                                "emi.com",
-                            ],
-                            secretName: "emi-com",
                         },
                     ],
                 },

--- a/test/core/pack/k8s/kubernetes/patch.test.ts
+++ b/test/core/pack/k8s/kubernetes/patch.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2020 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import { patchHeaders } from "../../../../../lib/core/pack/k8s/kubernetes/patch";
+
+describe("kubernetes/patch", () => {
+
+    describe("patchHeaders", () => {
+
+        it("should return default content type", () => {
+            [undefined, {}, { patchStrategy: undefined }].forEach((a: any) => {
+                const h = patchHeaders(a);
+                const e = {
+                    headers: {
+                        "Content-Type": "application/strategic-merge-patch+json",
+                    },
+                };
+                assert.deepStrictEqual(h, e);
+            });
+        });
+
+        it("should return provided patch strategy", () => {
+            ["application/merge-patch+json", "application/strategic-merge-patch+json"].forEach((s: any) => {
+                const h = patchHeaders({ patchStrategy: s });
+                const e = {
+                    headers: {
+                        "Content-Type": s,
+                    },
+                };
+                assert.deepStrictEqual(h, e);
+            });
+        });
+
+    });
+
+});


### PR DESCRIPTION
Allow setting of patch strategy in the KubernetesApplication interface. Remove single-use properties that are only proxies for values that can be provided in the various partial specs.