### PR TITLE
Query for credentials each k8s repo sync

### DIFF
--- a/lib/core/pack/k8s/sync/repo.ts
+++ b/lib/core/pack/k8s/sync/repo.ts
@@ -78,8 +78,7 @@ export async function queryForScmProvider(sdm: SoftwareDeliveryMachine): Promise
     }
     const repoRef = syncOptions.repo;
     if (!repoRef || !repoRef.owner || !repoRef.repo) {
-        logger.error(`Provided sync repo does not contain all required properties, deleting sync options: ${stringify(repoRef)}`);
-        delete sdm.configuration.sdm.k8s.options.sync;
+        logger.error(`Provided sync repo does not contain all required properties: ${stringify(repoRef)}`);
         return false;
     }
 
@@ -100,8 +99,7 @@ export async function queryForScmProvider(sdm: SoftwareDeliveryMachine): Promise
         }
         return true;
     }
-    logger.warn(`Failed to find sync repo, deleting sync options: ${stringify(repoRef)}`);
-    delete sdm.configuration.sdm.k8s.options.sync;
+    logger.warn(`Failed to find sync repo: ${stringify(repoRef)}`);
     return false;
 }
 

--- a/test/core/pack/k8s/sync/repo.test.ts
+++ b/test/core/pack/k8s/sync/repo.test.ts
@@ -39,7 +39,7 @@ import {
 
 const WorkspaceId = "A4USK34DU";
 
-describe("pack/k8s/sync/repo", () => {
+describe("core/pack/k8s/sync/repo", () => {
 
     describe("isRemoteRepo", () => {
 
@@ -876,7 +876,7 @@ describe("pack/k8s/sync/repo", () => {
             assert(ss.repo.scheme === "https://");
         });
 
-        it("should find nothing and delete sync options", async () => {
+        it("should find nothing", async () => {
             let queried = false;
             const s: SoftwareDeliveryMachine = {
                 configuration: {
@@ -914,7 +914,6 @@ describe("pack/k8s/sync/repo", () => {
             } as any;
             assert(!await queryForScmProvider(s));
             assert(queried, "query method never called");
-            assert(s.configuration.sdm.k8s.options.sync === undefined);
         });
 
         it("should find the repo via the provider", async () => {


### PR DESCRIPTION
Some credentials expire, so when a k8s sync repo interval is
configured, query the credentials from the graph prior to each sync.

Towards #828